### PR TITLE
Refactor schema representation to use maps for fields and input fields

### DIFF
--- a/internal/executor/executor_collect_test.go
+++ b/internal/executor/executor_collect_test.go
@@ -11,19 +11,10 @@ import (
 // Pattern: Result comparison
 func TestCollectFields_And_Directives_Result(t *testing.T) {
 	t.Run("Fragment merging and typename", func(t *testing.T) {
-		sch := &schema.Schema{
-			QueryType: "Query",
-			Types: map[string]*schema.Type{
-				"Query": {
-					Name: "Query",
-					Kind: schema.TypeKindObject,
-					Fields: map[string]*schema.Field{
-						"a": {Name: "a", Type: schema.NamedType("String"), Index: 0},
-					},
-				},
-				"String": {Name: "String", Kind: schema.TypeKindScalar},
-			},
-		}
+		sch := newSchemaWithQueryType(
+			newObjectType("Query", schema.NewField("a", "", schema.NamedType("String"))),
+			newScalarType("String"),
+		)
 		doc := mustParseQuery(t, `{
                         a
                         ...F1
@@ -48,21 +39,15 @@ func TestCollectFields_And_Directives_Result(t *testing.T) {
 	})
 
 	t.Run("Directives on scalar", func(t *testing.T) {
-		sch := &schema.Schema{
-			QueryType: "Query",
-			Types: map[string]*schema.Type{
-				"Query": {
-					Name: "Query",
-					Kind: schema.TypeKindObject,
-					Fields: map[string]*schema.Field{
-						"a": {Name: "a", Type: schema.NamedType("String"), Index: 0},
-						"b": {Name: "b", Type: schema.NamedType("String"), Index: 1},
-						"c": {Name: "c", Type: schema.NamedType("String"), Index: 2},
-					},
-				},
-				"String": {Name: "String", Kind: schema.TypeKindScalar},
-			},
-		}
+		sch := newSchemaWithQueryType(
+			newObjectType(
+				"Query",
+				schema.NewField("a", "", schema.NamedType("String")),
+				schema.NewField("b", "", schema.NamedType("String")),
+				schema.NewField("c", "", schema.NamedType("String")),
+			),
+			newScalarType("String"),
+		)
 		doc := mustParseQuery(t, `{ a b @skip(if: true) c @include(if: false) }`)
 		state := &executionState{schema: sch, document: doc, variableValues: map[string]any{}}
 		got := collectFields(state, sch.Types["Query"], doc.Operations[0].SelectionSet).orderedFields()
@@ -75,21 +60,15 @@ func TestCollectFields_And_Directives_Result(t *testing.T) {
 	})
 
 	t.Run("Directives on fragment spread", func(t *testing.T) {
-		sch := &schema.Schema{
-			QueryType: "Query",
-			Types: map[string]*schema.Type{
-				"Query": {
-					Name: "Query",
-					Kind: schema.TypeKindObject,
-					Fields: map[string]*schema.Field{
-						"a": {Name: "a", Type: schema.NamedType("String"), Index: 0},
-						"b": {Name: "b", Type: schema.NamedType("String"), Index: 1},
-						"c": {Name: "c", Type: schema.NamedType("String"), Index: 2},
-					},
-				},
-				"String": {Name: "String", Kind: schema.TypeKindScalar},
-			},
-		}
+		sch := newSchemaWithQueryType(
+			newObjectType(
+				"Query",
+				schema.NewField("a", "", schema.NamedType("String")),
+				schema.NewField("b", "", schema.NamedType("String")),
+				schema.NewField("c", "", schema.NamedType("String")),
+			),
+			newScalarType("String"),
+		)
 		doc := mustParseQuery(t, `{
                         a
                         ...Frag1 @include(if: true)
@@ -113,21 +92,15 @@ func TestCollectFields_And_Directives_Result(t *testing.T) {
 	})
 
 	t.Run("Directives on inline fragment", func(t *testing.T) {
-		sch := &schema.Schema{
-			QueryType: "Query",
-			Types: map[string]*schema.Type{
-				"Query": {
-					Name: "Query",
-					Kind: schema.TypeKindObject,
-					Fields: map[string]*schema.Field{
-						"a": {Name: "a", Type: schema.NamedType("String"), Index: 0},
-						"b": {Name: "b", Type: schema.NamedType("String"), Index: 1},
-						"c": {Name: "c", Type: schema.NamedType("String"), Index: 2},
-					},
-				},
-				"String": {Name: "String", Kind: schema.TypeKindScalar},
-			},
-		}
+		sch := newSchemaWithQueryType(
+			newObjectType(
+				"Query",
+				schema.NewField("a", "", schema.NamedType("String")),
+				schema.NewField("b", "", schema.NamedType("String")),
+				schema.NewField("c", "", schema.NamedType("String")),
+			),
+			newScalarType("String"),
+		)
 		doc := mustParseQuery(t, `{
                         a
                         ... on Query @include(if: true) { b }
@@ -148,21 +121,15 @@ func TestCollectFields_And_Directives_Result(t *testing.T) {
 	})
 
 	t.Run("Directives on anonymous inline fragment", func(t *testing.T) {
-		sch := &schema.Schema{
-			QueryType: "Query",
-			Types: map[string]*schema.Type{
-				"Query": {
-					Name: "Query",
-					Kind: schema.TypeKindObject,
-					Fields: schema.NewFieldMap(
-						&schema.Field{Name: "a", Type: schema.NamedType("String")},
-						&schema.Field{Name: "b", Type: schema.NamedType("String")},
-						&schema.Field{Name: "c", Type: schema.NamedType("String")},
-					),
-				},
-				"String": {Name: "String", Kind: schema.TypeKindScalar},
-			},
-		}
+		sch := newSchemaWithQueryType(
+			newObjectType(
+				"Query",
+				schema.NewField("a", "", schema.NamedType("String")),
+				schema.NewField("b", "", schema.NamedType("String")),
+				schema.NewField("c", "", schema.NamedType("String")),
+			),
+			newScalarType("String"),
+		)
 		doc := mustParseQuery(t, `{
                         a
                         ... @include(if: true) { b }

--- a/internal/executor/executor_collect_test.go
+++ b/internal/executor/executor_collect_test.go
@@ -14,7 +14,13 @@ func TestCollectFields_And_Directives_Result(t *testing.T) {
 		sch := &schema.Schema{
 			QueryType: "Query",
 			Types: map[string]*schema.Type{
-				"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "a", Type: schema.NamedType("String")}}},
+				"Query": {
+					Name: "Query",
+					Kind: schema.TypeKindObject,
+					Fields: map[string]*schema.Field{
+						"a": {Name: "a", Type: schema.NamedType("String"), Index: 0},
+					},
+				},
 				"String": {Name: "String", Kind: schema.TypeKindScalar},
 			},
 		}
@@ -45,11 +51,15 @@ func TestCollectFields_And_Directives_Result(t *testing.T) {
 		sch := &schema.Schema{
 			QueryType: "Query",
 			Types: map[string]*schema.Type{
-				"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: []*schema.Field{
-					{Name: "a", Type: schema.NamedType("String")},
-					{Name: "b", Type: schema.NamedType("String")},
-					{Name: "c", Type: schema.NamedType("String")},
-				}},
+				"Query": {
+					Name: "Query",
+					Kind: schema.TypeKindObject,
+					Fields: map[string]*schema.Field{
+						"a": {Name: "a", Type: schema.NamedType("String"), Index: 0},
+						"b": {Name: "b", Type: schema.NamedType("String"), Index: 1},
+						"c": {Name: "c", Type: schema.NamedType("String"), Index: 2},
+					},
+				},
 				"String": {Name: "String", Kind: schema.TypeKindScalar},
 			},
 		}
@@ -68,11 +78,15 @@ func TestCollectFields_And_Directives_Result(t *testing.T) {
 		sch := &schema.Schema{
 			QueryType: "Query",
 			Types: map[string]*schema.Type{
-				"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: []*schema.Field{
-					{Name: "a", Type: schema.NamedType("String")},
-					{Name: "b", Type: schema.NamedType("String")},
-					{Name: "c", Type: schema.NamedType("String")},
-				}},
+				"Query": {
+					Name: "Query",
+					Kind: schema.TypeKindObject,
+					Fields: map[string]*schema.Field{
+						"a": {Name: "a", Type: schema.NamedType("String"), Index: 0},
+						"b": {Name: "b", Type: schema.NamedType("String"), Index: 1},
+						"c": {Name: "c", Type: schema.NamedType("String"), Index: 2},
+					},
+				},
 				"String": {Name: "String", Kind: schema.TypeKindScalar},
 			},
 		}
@@ -102,11 +116,15 @@ func TestCollectFields_And_Directives_Result(t *testing.T) {
 		sch := &schema.Schema{
 			QueryType: "Query",
 			Types: map[string]*schema.Type{
-				"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: []*schema.Field{
-					{Name: "a", Type: schema.NamedType("String")},
-					{Name: "b", Type: schema.NamedType("String")},
-					{Name: "c", Type: schema.NamedType("String")},
-				}},
+				"Query": {
+					Name: "Query",
+					Kind: schema.TypeKindObject,
+					Fields: map[string]*schema.Field{
+						"a": {Name: "a", Type: schema.NamedType("String"), Index: 0},
+						"b": {Name: "b", Type: schema.NamedType("String"), Index: 1},
+						"c": {Name: "c", Type: schema.NamedType("String"), Index: 2},
+					},
+				},
 				"String": {Name: "String", Kind: schema.TypeKindScalar},
 			},
 		}
@@ -133,11 +151,15 @@ func TestCollectFields_And_Directives_Result(t *testing.T) {
 		sch := &schema.Schema{
 			QueryType: "Query",
 			Types: map[string]*schema.Type{
-				"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: []*schema.Field{
-					{Name: "a", Type: schema.NamedType("String")},
-					{Name: "b", Type: schema.NamedType("String")},
-					{Name: "c", Type: schema.NamedType("String")},
-				}},
+				"Query": {
+					Name: "Query",
+					Kind: schema.TypeKindObject,
+					Fields: schema.NewFieldMap(
+						&schema.Field{Name: "a", Type: schema.NamedType("String")},
+						&schema.Field{Name: "b", Type: schema.NamedType("String")},
+						&schema.Field{Name: "c", Type: schema.NamedType("String")},
+					),
+				},
 				"String": {Name: "String", Kind: schema.TypeKindScalar},
 			},
 		}

--- a/internal/executor/executor_complete_value_test.go
+++ b/internal/executor/executor_complete_value_test.go
@@ -19,19 +19,17 @@ func TestCompleteValue_NonNull_Propagation_Result(t *testing.T) {
 			QueryType: "Query",
 			Types: map[string]*schema.Type{
 				"Query": {
-					Name: "Query",
-					Kind: schema.TypeKindObject,
-					Fields: []*schema.Field{
-						{Name: "obj", Type: schema.NonNullType(schema.NamedType("Obj"))},
-					},
+					Name:   "Query",
+					Kind:   schema.TypeKindObject,
+					Fields: schema.NewFieldMap(&schema.Field{Name: "obj", Type: schema.NonNullType(schema.NamedType("Obj"))}),
 				},
 				"Obj": {
 					Name: "Obj",
 					Kind: schema.TypeKindObject,
-					Fields: []*schema.Field{
-						{Name: "a", Type: schema.NonNullType(schema.NamedType("String")), Async: false},
-						{Name: "b", Type: schema.NonNullType(schema.NamedType("String")), Async: true},
-					},
+					Fields: schema.NewFieldMap(
+						&schema.Field{Name: "a", Type: schema.NonNullType(schema.NamedType("String")), Async: false},
+						&schema.Field{Name: "b", Type: schema.NonNullType(schema.NamedType("String")), Async: true},
+					),
 				},
 				"String": {Name: "String", Kind: schema.TypeKindScalar},
 			},
@@ -78,19 +76,17 @@ func TestCompleteValue_NonNull_Propagation_Result(t *testing.T) {
 			QueryType: "Query",
 			Types: map[string]*schema.Type{
 				"Query": {
-					Name: "Query",
-					Kind: schema.TypeKindObject,
-					Fields: []*schema.Field{
-						{Name: "obj", Type: schema.NonNullType(schema.NamedType("Obj"))},
-					},
+					Name:   "Query",
+					Kind:   schema.TypeKindObject,
+					Fields: schema.NewFieldMap(&schema.Field{Name: "obj", Type: schema.NonNullType(schema.NamedType("Obj"))}),
 				},
 				"Obj": {
 					Name: "Obj",
 					Kind: schema.TypeKindObject,
-					Fields: []*schema.Field{
-						{Name: "a", Type: schema.NonNullType(schema.NamedType("String")), Async: false},
-						{Name: "b", Type: schema.NonNullType(schema.NamedType("String")), Async: true},
-					},
+					Fields: schema.NewFieldMap(
+						&schema.Field{Name: "a", Type: schema.NonNullType(schema.NamedType("String")), Async: false},
+						&schema.Field{Name: "b", Type: schema.NonNullType(schema.NamedType("String")), Async: true},
+					),
 				},
 				"String": {Name: "String", Kind: schema.TypeKindScalar},
 			},
@@ -138,7 +134,7 @@ func TestCompleteValue_List_Nullability_Result(t *testing.T) {
 				"Query": {
 					Name:   "Query",
 					Kind:   schema.TypeKindObject,
-					Fields: []*schema.Field{{Name: "list", Type: schema.ListType(schema.NamedType("String"))}},
+					Fields: schema.NewFieldMap(&schema.Field{Name: "list", Type: schema.ListType(schema.NamedType("String"))}),
 				},
 				"String": {Name: "String", Kind: schema.TypeKindScalar},
 			},
@@ -167,7 +163,7 @@ func TestCompleteValue_List_Nullability_Result(t *testing.T) {
 				"Query": {
 					Name:   "Query",
 					Kind:   schema.TypeKindObject,
-					Fields: []*schema.Field{{Name: "list", Type: schema.ListType(schema.NamedType("String"))}},
+					Fields: schema.NewFieldMap(&schema.Field{Name: "list", Type: schema.ListType(schema.NamedType("String"))}),
 				},
 				"String": {Name: "String", Kind: schema.TypeKindScalar},
 			},
@@ -196,7 +192,7 @@ func TestCompleteValue_List_Nullability_Result(t *testing.T) {
 				"Query": {
 					Name:   "Query",
 					Kind:   schema.TypeKindObject,
-					Fields: []*schema.Field{{Name: "list", Type: schema.ListType(schema.NamedType("String"))}},
+					Fields: schema.NewFieldMap(&schema.Field{Name: "list", Type: schema.ListType(schema.NamedType("String"))}),
 				},
 				"String": {Name: "String", Kind: schema.TypeKindScalar},
 			},
@@ -225,7 +221,7 @@ func TestCompleteValue_List_Nullability_Result(t *testing.T) {
 				"Query": {
 					Name:   "Query",
 					Kind:   schema.TypeKindObject,
-					Fields: []*schema.Field{{Name: "list", Type: schema.ListType(schema.NonNullType(schema.NamedType("String")))}},
+					Fields: schema.NewFieldMap(&schema.Field{Name: "list", Type: schema.ListType(schema.NonNullType(schema.NamedType("String")))}),
 				},
 				"String": {Name: "String", Kind: schema.TypeKindScalar},
 			},
@@ -256,11 +252,9 @@ func TestCompleteValue_Leaf_Serialization_Result(t *testing.T) {
 			QueryType: "Query",
 			Types: map[string]*schema.Type{
 				"Query": {
-					Name: "Query",
-					Kind: schema.TypeKindObject,
-					Fields: []*schema.Field{
-						{Name: "a", Type: schema.NamedType("String")},
-					},
+					Name:   "Query",
+					Kind:   schema.TypeKindObject,
+					Fields: schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("String")}),
 				},
 				"String": {Name: "String", Kind: schema.TypeKindScalar},
 			},
@@ -293,11 +287,9 @@ func TestCompleteValue_Leaf_Serialization_Result(t *testing.T) {
 			QueryType: "Query",
 			Types: map[string]*schema.Type{
 				"Query": {
-					Name: "Query",
-					Kind: schema.TypeKindObject,
-					Fields: []*schema.Field{
-						{Name: "a", Type: schema.NamedType("String")},
-					},
+					Name:   "Query",
+					Kind:   schema.TypeKindObject,
+					Fields: schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("String")}),
 				},
 				"String": {Name: "String", Kind: schema.TypeKindScalar},
 			},
@@ -331,15 +323,15 @@ func TestCompleteValue_Object_And_MixedSyncAsync_Result(t *testing.T) {
 			"Query": {
 				Name:   "Query",
 				Kind:   schema.TypeKindObject,
-				Fields: []*schema.Field{{Name: "obj", Type: schema.NamedType("Obj")}},
+				Fields: schema.NewFieldMap(&schema.Field{Name: "obj", Type: schema.NamedType("Obj")}),
 			},
 			"Obj": {
 				Name: "Obj",
 				Kind: schema.TypeKindObject,
-				Fields: []*schema.Field{
-					{Name: "a", Type: schema.NamedType("String"), Async: false},
-					{Name: "b", Type: schema.NamedType("String"), Async: true},
-				},
+				Fields: schema.NewFieldMap(
+					&schema.Field{Name: "a", Type: schema.NamedType("String"), Async: false},
+					&schema.Field{Name: "b", Type: schema.NamedType("String"), Async: true},
+				),
 			},
 			"String": {Name: "String", Kind: schema.TypeKindScalar},
 		},
@@ -381,9 +373,18 @@ func TestCompleteValue_Abstract_ResolveType_Result(t *testing.T) {
 		sch := &schema.Schema{
 			QueryType: "Query",
 			Types: map[string]*schema.Type{
-				"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "iface", Type: schema.NamedType("Node")}}},
-				"Node":   {Name: "Node", Kind: schema.TypeKindInterface, PossibleTypes: []string{"Obj"}},
-				"Obj":    {Name: "Obj", Kind: schema.TypeKindObject, Interfaces: []string{"Node"}, Fields: []*schema.Field{{Name: "a", Type: schema.NamedType("String")}}},
+				"Query": {
+					Name:   "Query",
+					Kind:   schema.TypeKindObject,
+					Fields: schema.NewFieldMap(&schema.Field{Name: "iface", Type: schema.NamedType("Node")}),
+				},
+				"Node": {Name: "Node", Kind: schema.TypeKindInterface, PossibleTypes: []string{"Obj"}},
+				"Obj": {
+					Name:       "Obj",
+					Kind:       schema.TypeKindObject,
+					Interfaces: []string{"Node"},
+					Fields:     schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("String")}),
+				},
 				"String": {Name: "String", Kind: schema.TypeKindScalar},
 			},
 		}
@@ -419,9 +420,18 @@ func TestCompleteValue_Abstract_ResolveType_Result(t *testing.T) {
 		sch := &schema.Schema{
 			QueryType: "Query",
 			Types: map[string]*schema.Type{
-				"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "iface", Type: schema.NamedType("Node")}}},
-				"Node":   {Name: "Node", Kind: schema.TypeKindInterface, PossibleTypes: []string{"Obj"}},
-				"Obj":    {Name: "Obj", Kind: schema.TypeKindObject, Interfaces: []string{"Node"}, Fields: []*schema.Field{{Name: "a", Type: schema.NamedType("String")}}},
+				"Query": {
+					Name:   "Query",
+					Kind:   schema.TypeKindObject,
+					Fields: schema.NewFieldMap(&schema.Field{Name: "iface", Type: schema.NamedType("Node")}),
+				},
+				"Node": {Name: "Node", Kind: schema.TypeKindInterface, PossibleTypes: []string{"Obj"}},
+				"Obj": {
+					Name:       "Obj",
+					Kind:       schema.TypeKindObject,
+					Interfaces: []string{"Node"},
+					Fields:     schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("String")}),
+				},
 				"String": {Name: "String", Kind: schema.TypeKindScalar},
 			},
 		}
@@ -453,9 +463,18 @@ func TestCompleteValue_Abstract_ResolveType_Result(t *testing.T) {
 		sch := &schema.Schema{
 			QueryType: "Query",
 			Types: map[string]*schema.Type{
-				"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "iface", Type: schema.NamedType("Node")}}},
-				"Node":   {Name: "Node", Kind: schema.TypeKindInterface, PossibleTypes: []string{"Obj"}},
-				"Obj":    {Name: "Obj", Kind: schema.TypeKindObject, Interfaces: []string{"Node"}, Fields: []*schema.Field{{Name: "a", Type: schema.NamedType("String")}}},
+				"Query": {
+					Name:   "Query",
+					Kind:   schema.TypeKindObject,
+					Fields: schema.NewFieldMap(&schema.Field{Name: "iface", Type: schema.NamedType("Node")}),
+				},
+				"Node": {Name: "Node", Kind: schema.TypeKindInterface, PossibleTypes: []string{"Obj"}},
+				"Obj": {
+					Name:       "Obj",
+					Kind:       schema.TypeKindObject,
+					Interfaces: []string{"Node"},
+					Fields:     schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("String")}),
+				},
 				"String": {Name: "String", Kind: schema.TypeKindScalar},
 			},
 		}

--- a/internal/executor/executor_context_test.go
+++ b/internal/executor/executor_context_test.go
@@ -14,7 +14,7 @@ func TestContext_OperationSelection_Result(t *testing.T) {
 		sch := &schema.Schema{
 			QueryType: "Query",
 			Types: map[string]*schema.Type{
-				"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "a", Type: schema.NamedType("String")}}},
+				"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("String")})},
 				"String": {Name: "String", Kind: schema.TypeKindScalar},
 			},
 		}
@@ -35,7 +35,7 @@ func TestContext_OperationSelection_Result(t *testing.T) {
 		sch := &schema.Schema{
 			QueryType: "Query",
 			Types: map[string]*schema.Type{
-				"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "a", Type: schema.NamedType("String")}}},
+				"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("String")})},
 				"String": {Name: "String", Kind: schema.TypeKindScalar},
 			},
 		}
@@ -54,7 +54,10 @@ func TestContext_OperationSelection_Result(t *testing.T) {
 		sch := &schema.Schema{
 			QueryType: "Query",
 			Types: map[string]*schema.Type{
-				"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "a", Type: schema.NamedType("String")}, {Name: "b", Type: schema.NamedType("String")}}},
+				"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(
+					&schema.Field{Name: "a", Type: schema.NamedType("String")},
+					&schema.Field{Name: "b", Type: schema.NamedType("String")},
+				)},
 				"String": {Name: "String", Kind: schema.TypeKindScalar},
 			},
 		}
@@ -118,7 +121,7 @@ func TestContext_VariableCoercion_Result(t *testing.T) {
 		sch := &schema.Schema{
 			QueryType: "Query",
 			Types: map[string]*schema.Type{
-				"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "echo", Type: schema.NamedType("Int"), Arguments: []*schema.InputValue{{Name: "v", Type: schema.NamedType("Int")}}}}},
+				"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "echo", Type: schema.NamedType("Int"), Arguments: schema.NewInputValueMap(&schema.InputValue{Name: "v", Type: schema.NamedType("Int")})})},
 				"Int":   {Name: "Int", Kind: schema.TypeKindScalar},
 			},
 		}
@@ -139,7 +142,7 @@ func TestContext_VariableCoercion_Result(t *testing.T) {
 		sch := &schema.Schema{
 			QueryType: "Query",
 			Types: map[string]*schema.Type{
-				"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "echo", Type: schema.NamedType("Int"), Arguments: []*schema.InputValue{{Name: "v", Type: schema.NamedType("Int")}}}}},
+				"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "echo", Type: schema.NamedType("Int"), Arguments: schema.NewInputValueMap(&schema.InputValue{Name: "v", Type: schema.NamedType("Int")})})},
 				"Int":   {Name: "Int", Kind: schema.TypeKindScalar},
 			},
 		}

--- a/internal/executor/executor_errors_paths_test.go
+++ b/internal/executor/executor_errors_paths_test.go
@@ -12,13 +12,10 @@ import (
 // Pattern: Result comparison
 func TestErrors_LocatedPaths_Result(t *testing.T) {
 	t.Run("Simple", func(t *testing.T) {
-		sch := &schema.Schema{
-			QueryType: "Query",
-			Types: map[string]*schema.Type{
-				"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("String")})},
-				"String": {Name: "String", Kind: schema.TypeKindScalar},
-			},
-		}
+		sch := newSchemaWithQueryType(
+			newObjectType("Query", schema.NewField("a", "", schema.NamedType("String"))),
+			newScalarType("String"),
+		)
 		rt := NewMockRuntime(map[string]MockResolver{
 			"Query.a": NewMockErrorResolver(fmt.Errorf("boom")),
 		})
@@ -37,14 +34,11 @@ func TestErrors_LocatedPaths_Result(t *testing.T) {
 	})
 
 	t.Run("Nested", func(t *testing.T) {
-		sch := &schema.Schema{
-			QueryType: "Query",
-			Types: map[string]*schema.Type{
-				"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "obj", Type: schema.NamedType("Obj")})},
-				"Obj":    {Name: "Obj", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("String")})},
-				"String": {Name: "String", Kind: schema.TypeKindScalar},
-			},
-		}
+		sch := newSchemaWithQueryType(
+			newObjectType("Query", schema.NewField("obj", "", schema.NamedType("Obj"))),
+			newObjectType("Obj", schema.NewField("a", "", schema.NamedType("String"))),
+			newScalarType("String"),
+		)
 		rt := NewMockRuntime(map[string]MockResolver{
 			"Query.obj": NewMockValueResolver(map[string]any{}),
 			"Obj.a":     NewMockErrorResolver(fmt.Errorf("boom")),
@@ -64,14 +58,11 @@ func TestErrors_LocatedPaths_Result(t *testing.T) {
 	})
 
 	t.Run("List index in path", func(t *testing.T) {
-		sch := &schema.Schema{
-			QueryType: "Query",
-			Types: map[string]*schema.Type{
-				"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "objs", Type: schema.ListType(schema.NamedType("Obj"))})},
-				"Obj":    {Name: "Obj", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("String")})},
-				"String": {Name: "String", Kind: schema.TypeKindScalar},
-			},
-		}
+		sch := newSchemaWithQueryType(
+			newObjectType("Query", schema.NewField("objs", "", schema.ListType(schema.NamedType("Obj")))),
+			newObjectType("Obj", schema.NewField("a", "", schema.NamedType("String"))),
+			newScalarType("String"),
+		)
 		rt := NewMockRuntime(map[string]MockResolver{
 			"Query.objs": NewMockValueResolver([]any{map[string]any{"idx": 0}, map[string]any{"idx": 1}}),
 			"Obj.a": func(ctx context.Context, src any, args map[string]any) (any, error) {

--- a/internal/executor/executor_errors_paths_test.go
+++ b/internal/executor/executor_errors_paths_test.go
@@ -15,7 +15,7 @@ func TestErrors_LocatedPaths_Result(t *testing.T) {
 		sch := &schema.Schema{
 			QueryType: "Query",
 			Types: map[string]*schema.Type{
-				"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "a", Type: schema.NamedType("String")}}},
+				"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("String")})},
 				"String": {Name: "String", Kind: schema.TypeKindScalar},
 			},
 		}
@@ -40,8 +40,8 @@ func TestErrors_LocatedPaths_Result(t *testing.T) {
 		sch := &schema.Schema{
 			QueryType: "Query",
 			Types: map[string]*schema.Type{
-				"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "obj", Type: schema.NamedType("Obj")}}},
-				"Obj":    {Name: "Obj", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "a", Type: schema.NamedType("String")}}},
+				"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "obj", Type: schema.NamedType("Obj")})},
+				"Obj":    {Name: "Obj", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("String")})},
 				"String": {Name: "String", Kind: schema.TypeKindScalar},
 			},
 		}
@@ -67,8 +67,8 @@ func TestErrors_LocatedPaths_Result(t *testing.T) {
 		sch := &schema.Schema{
 			QueryType: "Query",
 			Types: map[string]*schema.Type{
-				"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "objs", Type: schema.ListType(schema.NamedType("Obj"))}}},
-				"Obj":    {Name: "Obj", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "a", Type: schema.NamedType("String")}}},
+				"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "objs", Type: schema.ListType(schema.NamedType("Obj"))})},
+				"Obj":    {Name: "Obj", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("String")})},
 				"String": {Name: "String", Kind: schema.TypeKindScalar},
 			},
 		}

--- a/internal/executor/executor_isasync_routing_test.go
+++ b/internal/executor/executor_isasync_routing_test.go
@@ -18,10 +18,10 @@ func TestRouting_IsAsync_SyncVsAsync_Calls(t *testing.T) {
 			"Query": {
 				Name: "Query",
 				Kind: schema.TypeKindObject,
-				Fields: []*schema.Field{
-					{Name: "a", Type: schema.NamedType("String"), Async: false},
-					{Name: "b", Type: schema.NamedType("String"), Async: true},
-				},
+				Fields: schema.NewFieldMap(
+					&schema.Field{Name: "a", Type: schema.NamedType("String"), Async: false},
+					&schema.Field{Name: "b", Type: schema.NamedType("String"), Async: true},
+				),
 			},
 			"String": {Name: "String", Kind: schema.TypeKindScalar},
 		},
@@ -74,10 +74,10 @@ func TestRouting_DepthWiseBatch_Invariants_Calls(t *testing.T) {
 			"Query": {
 				Name: "Query",
 				Kind: schema.TypeKindObject,
-				Fields: []*schema.Field{
-					{Name: "a", Type: schema.NamedType("String"), Async: true},
-					{Name: "b", Type: schema.NamedType("String"), Async: true},
-				},
+				Fields: schema.NewFieldMap(
+					&schema.Field{Name: "a", Type: schema.NamedType("String"), Async: true},
+					&schema.Field{Name: "b", Type: schema.NamedType("String"), Async: true},
+				),
 			},
 			"String": {Name: "String", Kind: schema.TypeKindScalar},
 		},
@@ -117,8 +117,8 @@ func TestRouting_DepthWiseBatch_Invariants_Calls(t *testing.T) {
 	sch2 := &schema.Schema{
 		QueryType: "Query",
 		Types: map[string]*schema.Type{
-			"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "root", Type: schema.NamedType("Node"), Async: true}}},
-			"Node":   {Name: "Node", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "x", Type: schema.NamedType("String"), Async: true}}},
+			"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "root", Type: schema.NamedType("Node"), Async: true})},
+			"Node":   {Name: "Node", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "x", Type: schema.NamedType("String"), Async: true})},
 			"String": {Name: "String", Kind: schema.TypeKindScalar},
 		},
 	}
@@ -156,8 +156,11 @@ func TestRouting_DepthWiseBatch_Invariants_Calls(t *testing.T) {
 	sch3 := &schema.Schema{
 		QueryType: "Query",
 		Types: map[string]*schema.Type{
-			"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "root", Type: schema.NamedType("Node"), Async: true}}},
-			"Node":   {Name: "Node", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "child", Type: schema.NamedType("Node"), Async: true}, {Name: "x", Type: schema.NamedType("String"), Async: true}}},
+			"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "root", Type: schema.NamedType("Node"), Async: true})},
+			"Node": {Name: "Node", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(
+				&schema.Field{Name: "child", Type: schema.NamedType("Node"), Async: true},
+				&schema.Field{Name: "x", Type: schema.NamedType("String"), Async: true},
+			)},
 			"String": {Name: "String", Kind: schema.TypeKindScalar},
 		},
 	}

--- a/internal/executor/executor_ordering_test.go
+++ b/internal/executor/executor_ordering_test.go
@@ -10,21 +10,15 @@ import (
 
 // Pattern: Result comparison
 func TestOrdering_FieldOutput_Order_Result(t *testing.T) {
-	sch := &schema.Schema{
-		QueryType: "Query",
-		Types: map[string]*schema.Type{
-			"Query": {
-				Name: "Query",
-				Kind: schema.TypeKindObject,
-				Fields: schema.NewFieldMap(
-					&schema.Field{Name: "a", Type: schema.NamedType("String"), Async: false},
-					&schema.Field{Name: "b", Type: schema.NamedType("String"), Async: true},
-					&schema.Field{Name: "c", Type: schema.NamedType("String"), Async: false},
-				),
-			},
-			"String": {Name: "String", Kind: schema.TypeKindScalar},
-		},
-	}
+	sch := schema.NewSchema("").
+		SetQueryType("Query").
+		AddType(newObjectType(
+			"Query",
+			schema.NewField("a", "", schema.NamedType("String")),
+			schema.NewField("b", "", schema.NamedType("String")).SetAsync(true),
+			schema.NewField("c", "", schema.NamedType("String")),
+		)).
+		AddType(schema.NewType("String", schema.TypeKindScalar, ""))
 	rt := NewMockRuntime(map[string]MockResolver{
 		"Query.a": NewMockValueResolver("A"),
 		"Query.b": NewMockValueResolver("B"),
@@ -53,18 +47,16 @@ func TestOrdering_FieldOutput_Order_Result(t *testing.T) {
 
 // Pattern: Result comparison
 func TestOrdering_FragmentMerge_DuplicateFields_Result(t *testing.T) {
-	sch := &schema.Schema{
-		QueryType: "Query",
-		Types: map[string]*schema.Type{
-			"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "obj", Type: schema.NamedType("Obj")})},
-			"Obj":   {Name: "Obj", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("Sub")})},
-			"Sub": {Name: "Sub", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(
-				&schema.Field{Name: "x", Type: schema.NamedType("String")},
-				&schema.Field{Name: "y", Type: schema.NamedType("String")},
-			)},
-			"String": {Name: "String", Kind: schema.TypeKindScalar},
-		},
-	}
+	sch := schema.NewSchema("").
+		SetQueryType("Query").
+		AddType(newObjectType("Query", schema.NewField("obj", "", schema.NamedType("Obj")))).
+		AddType(newObjectType("Obj", schema.NewField("a", "", schema.NamedType("Sub")))).
+		AddType(newObjectType(
+			"Sub",
+			schema.NewField("x", "", schema.NamedType("String")),
+			schema.NewField("y", "", schema.NamedType("String")),
+		)).
+		AddType(schema.NewType("String", schema.TypeKindScalar, ""))
 	rt := NewMockRuntime(map[string]MockResolver{
 		"Query.obj": NewMockValueResolver(map[string]any{}),
 		"Obj.a":     NewMockValueResolver(map[string]any{}),

--- a/internal/executor/executor_ordering_test.go
+++ b/internal/executor/executor_ordering_test.go
@@ -16,11 +16,11 @@ func TestOrdering_FieldOutput_Order_Result(t *testing.T) {
 			"Query": {
 				Name: "Query",
 				Kind: schema.TypeKindObject,
-				Fields: []*schema.Field{
-					{Name: "a", Type: schema.NamedType("String"), Async: false},
-					{Name: "b", Type: schema.NamedType("String"), Async: true},
-					{Name: "c", Type: schema.NamedType("String"), Async: false},
-				},
+				Fields: schema.NewFieldMap(
+					&schema.Field{Name: "a", Type: schema.NamedType("String"), Async: false},
+					&schema.Field{Name: "b", Type: schema.NamedType("String"), Async: true},
+					&schema.Field{Name: "c", Type: schema.NamedType("String"), Async: false},
+				),
 			},
 			"String": {Name: "String", Kind: schema.TypeKindScalar},
 		},
@@ -56,9 +56,12 @@ func TestOrdering_FragmentMerge_DuplicateFields_Result(t *testing.T) {
 	sch := &schema.Schema{
 		QueryType: "Query",
 		Types: map[string]*schema.Type{
-			"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "obj", Type: schema.NamedType("Obj")}}},
-			"Obj":    {Name: "Obj", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "a", Type: schema.NamedType("Sub")}}},
-			"Sub":    {Name: "Sub", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "x", Type: schema.NamedType("String")}, {Name: "y", Type: schema.NamedType("String")}}},
+			"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "obj", Type: schema.NamedType("Obj")})},
+			"Obj":   {Name: "Obj", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("Sub")})},
+			"Sub": {Name: "Sub", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(
+				&schema.Field{Name: "x", Type: schema.NamedType("String")},
+				&schema.Field{Name: "y", Type: schema.NamedType("String")},
+			)},
 			"String": {Name: "String", Kind: schema.TypeKindScalar},
 		},
 	}

--- a/internal/executor/executor_root_mutation_test.go
+++ b/internal/executor/executor_root_mutation_test.go
@@ -14,7 +14,7 @@ func TestRoot_Query_IsAsync_Depth0Batch_Calls(t *testing.T) {
 	sch := &schema.Schema{
 		QueryType: "Query",
 		Types: map[string]*schema.Type{
-			"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "a", Type: schema.NamedType("String"), Async: true}}},
+			"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("String"), Async: true})},
 			"String": {Name: "String", Kind: schema.TypeKindScalar},
 		},
 	}
@@ -41,9 +41,13 @@ func TestMutation_Serial_Evaluation_Order_Result(t *testing.T) {
 		QueryType:    "Query",
 		MutationType: "Mutation",
 		Types: map[string]*schema.Type{
-			"Query":    {Name: "Query", Kind: schema.TypeKindObject},
-			"Mutation": {Name: "Mutation", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "m1", Type: schema.NamedType("String")}, {Name: "m2", Type: schema.NamedType("String")}, {Name: "m3", Type: schema.NamedType("String")}}},
-			"String":   {Name: "String", Kind: schema.TypeKindScalar},
+			"Query": {Name: "Query", Kind: schema.TypeKindObject},
+			"Mutation": {Name: "Mutation", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(
+				&schema.Field{Name: "m1", Type: schema.NamedType("String")},
+				&schema.Field{Name: "m2", Type: schema.NamedType("String")},
+				&schema.Field{Name: "m3", Type: schema.NamedType("String")},
+			)},
+			"String": {Name: "String", Kind: schema.TypeKindScalar},
 		},
 	}
 	rt := NewMockRuntime(map[string]MockResolver{

--- a/internal/executor/executor_runtime_contract_test.go
+++ b/internal/executor/executor_runtime_contract_test.go
@@ -11,16 +11,14 @@ import (
 
 // Pattern: Calls comparison
 func TestRuntimeContract_Routing_SyncVsBatch_Calls(t *testing.T) {
-	sch := &schema.Schema{
-		QueryType: "Query",
-		Types: map[string]*schema.Type{
-			"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(
-				&schema.Field{Name: "a", Type: schema.NamedType("String")},
-				&schema.Field{Name: "b", Type: schema.NamedType("String"), Async: true},
-			)},
-			"String": {Name: "String", Kind: schema.TypeKindScalar},
-		},
-	}
+	sch := newSchemaWithQueryType(
+		newObjectType(
+			"Query",
+			schema.NewField("a", "", schema.NamedType("String")),
+			schema.NewField("b", "", schema.NamedType("String")).SetAsync(true),
+		),
+		newScalarType("String"),
+	)
 	rt := NewMockRuntime(map[string]MockResolver{
 		"Query.a": NewMockValueResolver("A"),
 		"Query.b": NewMockValueResolver("B"),
@@ -42,18 +40,15 @@ func TestRuntimeContract_Routing_SyncVsBatch_Calls(t *testing.T) {
 
 // Pattern: Calls comparison
 func TestRuntimeContract_PayloadTransparency_Calls(t *testing.T) {
-	sch := &schema.Schema{
-		QueryType: "Query",
-		Types: map[string]*schema.Type{
-			"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "obj", Type: schema.NamedType("Obj")})},
-			"Obj": {
-				Name:   "Obj",
-				Kind:   schema.TypeKindObject,
-				Fields: schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("String"), Arguments: schema.NewInputValueMap(&schema.InputValue{Name: "arg", Type: schema.NamedType("String")})}),
-			},
-			"String": {Name: "String", Kind: schema.TypeKindScalar},
-		},
-	}
+	sch := newSchemaWithQueryType(
+		newObjectType("Query", schema.NewField("obj", "", schema.NamedType("Obj"))),
+		newObjectType(
+			"Obj",
+			schema.NewField("a", "", schema.NamedType("String")).
+				AddArgument(schema.NewInputValue("arg", "", schema.NamedType("String"))),
+		),
+		newScalarType("String"),
+	)
 	rt := NewMockRuntime(map[string]MockResolver{
 		"Query.obj": NewMockValueResolver(map[string]any{"token": "root"}),
 		"Obj.a":     func(ctx context.Context, src any, args map[string]any) (any, error) { return "A", nil },
@@ -75,16 +70,14 @@ func TestRuntimeContract_PayloadTransparency_Calls(t *testing.T) {
 
 // Pattern: Calls comparison
 func TestRuntimeContract_BatchBoundary_SingleBatchPerDepth_Calls(t *testing.T) {
-	sch := &schema.Schema{
-		QueryType: "Query",
-		Types: map[string]*schema.Type{
-			"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(
-				&schema.Field{Name: "a", Type: schema.NamedType("String"), Async: true},
-				&schema.Field{Name: "b", Type: schema.NamedType("String"), Async: true},
-			)},
-			"String": {Name: "String", Kind: schema.TypeKindScalar},
-		},
-	}
+	sch := newSchemaWithQueryType(
+		newObjectType(
+			"Query",
+			schema.NewField("a", "", schema.NamedType("String")).SetAsync(true),
+			schema.NewField("b", "", schema.NamedType("String")).SetAsync(true),
+		),
+		newScalarType("String"),
+	)
 	rt := NewMockRuntime(map[string]MockResolver{
 		"Query.a": NewMockValueResolver("A"),
 		"Query.b": NewMockValueResolver("B"),
@@ -106,20 +99,16 @@ func TestRuntimeContract_BatchBoundary_SingleBatchPerDepth_Calls(t *testing.T) {
 
 // Pattern: Calls + Result comparison
 func TestRuntimeContract_HookInvocation_Serialize_ResolveType_CallsAndResult(t *testing.T) {
-	sch := &schema.Schema{
-		QueryType: "Query",
-		Types: map[string]*schema.Type{
-			"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "iface", Type: schema.NamedType("Node")})},
-			"Node":  {Name: "Node", Kind: schema.TypeKindInterface, PossibleTypes: []string{"Obj"}},
-			"Obj": {
-				Name:       "Obj",
-				Kind:       schema.TypeKindObject,
-				Interfaces: []string{"Node"},
-				Fields:     schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("String")}),
-			},
-			"String": {Name: "String", Kind: schema.TypeKindScalar},
-		},
-	}
+	nodeType := schema.NewType("Node", schema.TypeKindInterface, "").AddPossibleType("Obj")
+	objType := newObjectType("Obj", schema.NewField("a", "", schema.NamedType("String")))
+	objType.AddInterface("Node")
+
+	sch := newSchemaWithQueryType(
+		newObjectType("Query", schema.NewField("iface", "", schema.NamedType("Node"))),
+		nodeType,
+		objType,
+		newScalarType("String"),
+	)
 	rt := NewMockRuntime(map[string]MockResolver{
 		"Query.iface": NewMockValueResolver(map[string]any{}),
 		"Obj.a":       NewMockValueResolver("A"),
@@ -154,16 +143,14 @@ func TestRuntimeContract_HookInvocation_Serialize_ResolveType_CallsAndResult(t *
 
 // Pattern: Calls + Result comparison
 func TestRuntimeContract_CancellationTimeouts_PartialFailure_CallsAndResult(t *testing.T) {
-	sch := &schema.Schema{
-		QueryType: "Query",
-		Types: map[string]*schema.Type{
-			"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(
-				&schema.Field{Name: "a", Type: schema.NamedType("String"), Async: true},
-				&schema.Field{Name: "b", Type: schema.NamedType("String"), Async: true},
-			)},
-			"String": {Name: "String", Kind: schema.TypeKindScalar},
-		},
-	}
+	sch := newSchemaWithQueryType(
+		newObjectType(
+			"Query",
+			schema.NewField("a", "", schema.NamedType("String")).SetAsync(true),
+			schema.NewField("b", "", schema.NamedType("String")).SetAsync(true),
+		),
+		newScalarType("String"),
+	)
 	rt := NewMockRuntime(map[string]MockResolver{
 		"Query.a": NewMockErrorResolver(fmt.Errorf("boom")),
 		"Query.b": NewMockValueResolver("B"),

--- a/internal/executor/executor_runtime_contract_test.go
+++ b/internal/executor/executor_runtime_contract_test.go
@@ -14,7 +14,10 @@ func TestRuntimeContract_Routing_SyncVsBatch_Calls(t *testing.T) {
 	sch := &schema.Schema{
 		QueryType: "Query",
 		Types: map[string]*schema.Type{
-			"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "a", Type: schema.NamedType("String")}, {Name: "b", Type: schema.NamedType("String"), Async: true}}},
+			"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(
+				&schema.Field{Name: "a", Type: schema.NamedType("String")},
+				&schema.Field{Name: "b", Type: schema.NamedType("String"), Async: true},
+			)},
 			"String": {Name: "String", Kind: schema.TypeKindScalar},
 		},
 	}
@@ -42,8 +45,12 @@ func TestRuntimeContract_PayloadTransparency_Calls(t *testing.T) {
 	sch := &schema.Schema{
 		QueryType: "Query",
 		Types: map[string]*schema.Type{
-			"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "obj", Type: schema.NamedType("Obj")}}},
-			"Obj":    {Name: "Obj", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "a", Type: schema.NamedType("String"), Arguments: []*schema.InputValue{{Name: "arg", Type: schema.NamedType("String")}}}}},
+			"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "obj", Type: schema.NamedType("Obj")})},
+			"Obj": {
+				Name:   "Obj",
+				Kind:   schema.TypeKindObject,
+				Fields: schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("String"), Arguments: schema.NewInputValueMap(&schema.InputValue{Name: "arg", Type: schema.NamedType("String")})}),
+			},
 			"String": {Name: "String", Kind: schema.TypeKindScalar},
 		},
 	}
@@ -71,7 +78,10 @@ func TestRuntimeContract_BatchBoundary_SingleBatchPerDepth_Calls(t *testing.T) {
 	sch := &schema.Schema{
 		QueryType: "Query",
 		Types: map[string]*schema.Type{
-			"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "a", Type: schema.NamedType("String"), Async: true}, {Name: "b", Type: schema.NamedType("String"), Async: true}}},
+			"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(
+				&schema.Field{Name: "a", Type: schema.NamedType("String"), Async: true},
+				&schema.Field{Name: "b", Type: schema.NamedType("String"), Async: true},
+			)},
 			"String": {Name: "String", Kind: schema.TypeKindScalar},
 		},
 	}
@@ -99,9 +109,14 @@ func TestRuntimeContract_HookInvocation_Serialize_ResolveType_CallsAndResult(t *
 	sch := &schema.Schema{
 		QueryType: "Query",
 		Types: map[string]*schema.Type{
-			"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "iface", Type: schema.NamedType("Node")}}},
-			"Node":   {Name: "Node", Kind: schema.TypeKindInterface, PossibleTypes: []string{"Obj"}},
-			"Obj":    {Name: "Obj", Kind: schema.TypeKindObject, Interfaces: []string{"Node"}, Fields: []*schema.Field{{Name: "a", Type: schema.NamedType("String")}}},
+			"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "iface", Type: schema.NamedType("Node")})},
+			"Node":  {Name: "Node", Kind: schema.TypeKindInterface, PossibleTypes: []string{"Obj"}},
+			"Obj": {
+				Name:       "Obj",
+				Kind:       schema.TypeKindObject,
+				Interfaces: []string{"Node"},
+				Fields:     schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("String")}),
+			},
 			"String": {Name: "String", Kind: schema.TypeKindScalar},
 		},
 	}
@@ -142,7 +157,10 @@ func TestRuntimeContract_CancellationTimeouts_PartialFailure_CallsAndResult(t *t
 	sch := &schema.Schema{
 		QueryType: "Query",
 		Types: map[string]*schema.Type{
-			"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: []*schema.Field{{Name: "a", Type: schema.NamedType("String"), Async: true}, {Name: "b", Type: schema.NamedType("String"), Async: true}}},
+			"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(
+				&schema.Field{Name: "a", Type: schema.NamedType("String"), Async: true},
+				&schema.Field{Name: "b", Type: schema.NamedType("String"), Async: true},
+			)},
 			"String": {Name: "String", Kind: schema.TypeKindScalar},
 		},
 	}

--- a/internal/executor/fields.go
+++ b/internal/executor/fields.go
@@ -186,10 +186,8 @@ func getFragmentDefinition(document *language.QueryDocument, name string) *langu
 }
 
 func getFieldDefinition(objectType *schema.Type, fieldName string) *schema.Field {
-	for _, field := range objectType.Fields {
-		if field.Name == fieldName {
-			return field
-		}
+	if objectType == nil {
+		return nil
 	}
-	return nil
+	return objectType.Field(fieldName)
 }

--- a/internal/executor/schema_external_test_helpers_test.go
+++ b/internal/executor/schema_external_test_helpers_test.go
@@ -1,0 +1,27 @@
+package executor_test
+
+import schema "github.com/hanpama/protograph/internal/schema"
+
+func newSchemaWithQueryType(query *schema.Type, additional ...*schema.Type) *schema.Schema {
+	sch := schema.NewSchema("")
+	if query != nil {
+		sch.SetQueryType(query.Name)
+		sch.AddType(query)
+	}
+	for _, t := range additional {
+		sch.AddType(t)
+	}
+	return sch
+}
+
+func newObjectType(name string, fields ...*schema.Field) *schema.Type {
+	t := schema.NewType(name, schema.TypeKindObject, "")
+	for _, field := range fields {
+		t.AddField(field)
+	}
+	return t
+}
+
+func newScalarType(name string) *schema.Type {
+	return schema.NewType(name, schema.TypeKindScalar, "")
+}

--- a/internal/executor/schema_test_helpers.go
+++ b/internal/executor/schema_test_helpers.go
@@ -1,0 +1,27 @@
+package executor
+
+import schema "github.com/hanpama/protograph/internal/schema"
+
+func newSchemaWithQueryType(query *schema.Type, additional ...*schema.Type) *schema.Schema {
+	sch := schema.NewSchema("")
+	if query != nil {
+		sch.SetQueryType(query.Name)
+		sch.AddType(query)
+	}
+	for _, t := range additional {
+		sch.AddType(t)
+	}
+	return sch
+}
+
+func newObjectType(name string, fields ...*schema.Field) *schema.Type {
+	t := schema.NewType(name, schema.TypeKindObject, "")
+	for _, field := range fields {
+		t.AddField(field)
+	}
+	return t
+}
+
+func newScalarType(name string) *schema.Type {
+	return schema.NewType(name, schema.TypeKindScalar, "")
+}

--- a/internal/executor/values.go
+++ b/internal/executor/values.go
@@ -60,13 +60,7 @@ func coerceArgumentValues(
 ) map[string]any {
 	coerced := make(map[string]any)
 	for _, arg := range arguments {
-		var argDef *schema.InputValue
-		for _, a := range fieldDef.Arguments {
-			if a.Name == arg.Name {
-				argDef = a
-				break
-			}
-		}
+		argDef := fieldDef.Argument(arg.Name)
 		if argDef == nil {
 			continue
 		}
@@ -78,7 +72,7 @@ func coerceArgumentValues(
 		}
 		coerced[arg.Name] = cv
 	}
-	for _, argDef := range fieldDef.Arguments {
+	for _, argDef := range fieldDef.GetOrderedArguments() {
 		name := argDef.Name
 		if _, ok := coerced[name]; !ok {
 			if argDef.DefaultValue != nil {

--- a/internal/introspection/runtime.go
+++ b/internal/introspection/runtime.go
@@ -134,7 +134,7 @@ func resolveTypeFields(t *schema.Type, args map[string]any) []*schema.Field {
 	}
 	includeDeprecated := boolArg(args, "includeDeprecated", false)
 	out := []*schema.Field{}
-	for _, f := range t.Fields {
+	for _, f := range t.GetOrderedFields() {
 		if !includeDeprecated && f.IsDeprecated {
 			continue
 		}
@@ -194,7 +194,7 @@ func resolveTypeInputFields(t *schema.Type, args map[string]any) []*schema.Input
 	}
 	includeDeprecated := boolArg(args, "includeDeprecated", false)
 	out := []*schema.InputValue{}
-	for _, iv := range t.InputFields {
+	for _, iv := range t.GetOrderedInputFields() {
 		if !includeDeprecated && iv.IsDeprecated {
 			continue
 		}
@@ -207,7 +207,7 @@ func resolveTypeInputFields(t *schema.Type, args map[string]any) []*schema.Input
 func resolveFieldArgs(f *schema.Field, args map[string]any) []*schema.InputValue {
 	includeDeprecated := boolArg(args, "includeDeprecated", false)
 	out := []*schema.InputValue{}
-	for _, a := range f.Arguments {
+	for _, a := range f.GetOrderedArguments() {
 		if !includeDeprecated && a.IsDeprecated {
 			continue
 		}

--- a/internal/introspection/schema.go
+++ b/internal/introspection/schema.go
@@ -6,315 +6,423 @@ import (
 
 // extendSchemaWithIntrospection creates a copy of the schema and adds introspection types and fields
 func extendSchemaWithIntrospection(original *schema.Schema) *schema.Schema {
-	// Create a shallow copy of the schema
-	extended := &schema.Schema{
-		QueryType:        original.QueryType,
-		MutationType:     original.MutationType,
-		SubscriptionType: original.SubscriptionType,
-		Types:            make(map[string]*schema.Type),
-		Directives:       original.Directives,
-		Description:      original.Description,
+	extended := schema.NewSchema(original.Description).
+		SetQueryType(original.QueryType).
+		SetMutationType(original.MutationType).
+		SetSubscriptionType(original.SubscriptionType)
+
+	// Share existing directives snapshot (immutable in practice)
+	extended.Directives = original.Directives
+
+	for _, typ := range original.Types {
+		extended.AddType(typ)
 	}
-	
-	// Copy all original types
-	for name, typ := range original.Types {
-		extended.Types[name] = typ
-	}
-	
-	// Add introspection types
+
 	addIntrospectionTypes(extended)
-	
-	// Add __schema and __type fields to Query type
+
 	if queryType := extended.GetQueryType(); queryType != nil {
-		// Create a copy of the Query type to add fields
-		queryTypeCopy := &schema.Type{
-			Name:        queryType.Name,
-			Kind:        queryType.Kind,
-			Description: queryType.Description,
-			Fields:      make([]*schema.Field, len(queryType.Fields)),
-			Interfaces:  queryType.Interfaces,
+		queryTypeCopy := schema.NewType(queryType.Name, queryType.Kind, queryType.Description)
+		for _, iface := range queryType.Interfaces {
+			queryTypeCopy.AddInterface(iface)
 		}
-		
-		// Copy existing fields
-		copy(queryTypeCopy.Fields, queryType.Fields)
-		
-		// Add introspection fields
-		queryTypeCopy.Fields = append(queryTypeCopy.Fields,
-			&schema.Field{
-				Name:        "__schema",
-				Description: "Access the current type schema of this server.",
-				Type:        schema.NonNullType(schema.NamedType("__Schema")),
-				Async:       false,
-			},
-			&schema.Field{
-				Name:        "__type",
-				Description: "Request the type information of a single type.",
-				Arguments: []*schema.InputValue{
-					{
-						Name:        "name",
-						Description: "The name of the type to look up.",
-						Type:        schema.NonNullType(schema.NamedType("String")),
-					},
-				},
-				Type:  schema.NamedType("__Type"),
-				Async: false,
-			},
+		for _, field := range queryType.GetOrderedFields() {
+			queryTypeCopy.AddField(cloneField(field))
+		}
+
+		queryTypeCopy.AddField(schema.NewField(
+			"__schema",
+			"Access the current type schema of this server.",
+			schema.NonNullType(schema.NamedType("__Schema")),
+		))
+
+		typeField := schema.NewField(
+			"__type",
+			"Request the type information of a single type.",
+			schema.NamedType("__Type"),
 		)
-		
-		extended.Types["Query"] = queryTypeCopy
+		typeField.AddArgument(
+			schema.NewInputValue(
+				"name",
+				"The name of the type to look up.",
+				schema.NonNullType(schema.NamedType("String")),
+			),
+		)
+		queryTypeCopy.AddField(typeField)
+
+		extended.AddType(queryTypeCopy)
 	}
-	
+
 	return extended
 }
 
 // addIntrospectionTypes adds the introspection types to the schema
 func addIntrospectionTypes(sch *schema.Schema) {
-	sch.Types["__Schema"] = schemaType()
-	sch.Types["__Type"] = typeType()
-	sch.Types["__Field"] = fieldType()
-	sch.Types["__InputValue"] = inputValueType()
-	sch.Types["__EnumValue"] = enumValueType()
-	sch.Types["__Directive"] = directiveType()
-	sch.Types["__TypeKind"] = typeKindEnum()
-	sch.Types["__DirectiveLocation"] = directiveLocationEnum()
+	sch.AddType(schemaType()).
+		AddType(typeType()).
+		AddType(fieldType()).
+		AddType(inputValueType()).
+		AddType(enumValueType()).
+		AddType(directiveType()).
+		AddType(typeKindEnum()).
+		AddType(directiveLocationEnum())
 }
 
 // schemaType returns the __Schema introspection type definition
 func schemaType() *schema.Type {
-	return &schema.Type{
-		Name:        "__Schema",
-		Kind:        schema.TypeKindObject,
-		Description: "A GraphQL Schema defines the capabilities of a GraphQL server.",
-		Fields: []*schema.Field{
-			{
-				Name:        "types",
-				Description: "A list of all types supported by this server.",
-				Type:        schema.NonNullType(schema.ListType(schema.NonNullType(schema.NamedType("__Type")))),
-			},
-			{
-				Name:        "queryType",
-				Description: "The type that query operations will be rooted at.",
-				Type:        schema.NonNullType(schema.NamedType("__Type")),
-			},
-			{
-				Name:        "mutationType",
-				Description: "If this server supports mutation, the type that mutation operations will be rooted at.",
-				Type:        schema.NamedType("__Type"),
-			},
-			{
-				Name:        "subscriptionType",
-				Description: "If this server support subscription, the type that subscription operations will be rooted at.",
-				Type:        schema.NamedType("__Type"),
-			},
-			{
-				Name:        "directives",
-				Description: "A list of all directives supported by this server.",
-				Type:        schema.NonNullType(schema.ListType(schema.NonNullType(schema.NamedType("__Directive")))),
-			},
-			{
-				Name:        "description",
-				Description: "A description of the schema.",
-				Type:        schema.NamedType("String"),
-			},
-		},
-	}
+	t := schema.NewType(
+		"__Schema",
+		schema.TypeKindObject,
+		"A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
+	)
+	t.AddField(schema.NewField(
+		"types",
+		"A list of all types supported by this server.",
+		schema.NonNullType(schema.ListType(schema.NonNullType(schema.NamedType("__Type")))),
+	))
+	t.AddField(schema.NewField(
+		"queryType",
+		"The type that query operations will be rooted at.",
+		schema.NonNullType(schema.NamedType("__Type")),
+	))
+	t.AddField(schema.NewField(
+		"mutationType",
+		"If this server supports mutation, the type that mutation operations will be rooted at.",
+		schema.NamedType("__Type"),
+	))
+	t.AddField(schema.NewField(
+		"subscriptionType",
+		"If this server supports subscription, the type that subscription operations will be rooted at.",
+		schema.NamedType("__Type"),
+	))
+	t.AddField(schema.NewField(
+		"directives",
+		"A list of all directives supported by this server.",
+		schema.NonNullType(schema.ListType(schema.NonNullType(schema.NamedType("__Directive")))),
+	))
+	t.AddField(schema.NewField(
+		"description",
+		"A description of this schema.",
+		schema.NamedType("String"),
+	))
+	return t
 }
 
 // typeType returns the __Type introspection type definition
 func typeType() *schema.Type {
-	return &schema.Type{
-		Name:        "__Type",
-		Kind:        schema.TypeKindObject,
-		Description: "The fundamental unit of any GraphQL Schema is the type.",
-		Fields: []*schema.Field{
-			{
-				Name:        "kind",
-				Description: "The kind of type.",
-				Type:        schema.NonNullType(schema.NamedType("__TypeKind")),
-			},
-			{
-				Name:        "name",
-				Description: "The name of the type.",
-				Type:        schema.NamedType("String"),
-			},
-			{
-				Name:        "description",
-				Description: "The description of the type.",
-				Type:        schema.NamedType("String"),
-			},
-			{
-				Name: "fields",
-				Arguments: []*schema.InputValue{
-					{
-						Name:         "includeDeprecated",
-						Type:         schema.NamedType("Boolean"),
-						DefaultValue: false,
-					},
-				},
-				Type: schema.ListType(schema.NonNullType(schema.NamedType("__Field"))),
-			},
-			{
-				Name: "interfaces",
-				Type: schema.ListType(schema.NonNullType(schema.NamedType("__Type"))),
-			},
-			{
-				Name: "possibleTypes",
-				Type: schema.ListType(schema.NonNullType(schema.NamedType("__Type"))),
-			},
-			{
-				Name: "enumValues",
-				Arguments: []*schema.InputValue{
-					{
-						Name:         "includeDeprecated",
-						Type:         schema.NamedType("Boolean"),
-						DefaultValue: false,
-					},
-				},
-				Type: schema.ListType(schema.NonNullType(schema.NamedType("__EnumValue"))),
-			},
-			{
-				Name: "inputFields",
-				Arguments: []*schema.InputValue{
-					{
-						Name:         "includeDeprecated",
-						Type:         schema.NamedType("Boolean"),
-						DefaultValue: false,
-					},
-				},
-				Type: schema.ListType(schema.NonNullType(schema.NamedType("__InputValue"))),
-			},
-			{
-				Name: "ofType",
-				Type: schema.NamedType("__Type"),
-			},
-			{
-				Name: "specifiedByURL",
-				Type: schema.NamedType("String"),
-			},
-			{
-				Name: "isOneOf",
-				Type: schema.NamedType("Boolean"),
-			},
-		},
-	}
+	t := schema.NewType(
+		"__Type",
+		schema.TypeKindObject,
+		"The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional `specifiedByURL`, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+	)
+	t.AddField(schema.NewField(
+		"kind",
+		"The kind of type.",
+		schema.NonNullType(schema.NamedType("__TypeKind")),
+	))
+	t.AddField(schema.NewField(
+		"name",
+		"The name of the type.",
+		schema.NamedType("String"),
+	))
+	t.AddField(schema.NewField(
+		"description",
+		"The description of the type.",
+		schema.NamedType("String"),
+	))
+	fieldsField := schema.NewField(
+		"fields",
+		"Fields on this type, including deprecated fields if `includeDeprecated` is true.",
+		schema.ListType(schema.NonNullType(schema.NamedType("__Field"))),
+	)
+	fieldsField.AddArgument(schema.NewInputValue(
+		"includeDeprecated",
+		"Include deprecated fields in the results.",
+		schema.NamedType("Boolean"),
+	).SetDefault(false))
+	t.AddField(fieldsField)
+	t.AddField(schema.NewField(
+		"interfaces",
+		"Interfaces implemented by this type.",
+		schema.ListType(schema.NonNullType(schema.NamedType("__Type"))),
+	))
+	t.AddField(schema.NewField(
+		"possibleTypes",
+		"Possible concrete types for this abstract type.",
+		schema.ListType(schema.NonNullType(schema.NamedType("__Type"))),
+	))
+	enumValuesField := schema.NewField(
+		"enumValues",
+		"Values for this enum type, including deprecated values if `includeDeprecated` is true.",
+		schema.ListType(schema.NonNullType(schema.NamedType("__EnumValue"))),
+	)
+	enumValuesField.AddArgument(schema.NewInputValue(
+		"includeDeprecated",
+		"Include deprecated enum values in the results.",
+		schema.NamedType("Boolean"),
+	).SetDefault(false))
+	t.AddField(enumValuesField)
+	inputFieldsField := schema.NewField(
+		"inputFields",
+		"Input fields for this input object, including deprecated input fields if `includeDeprecated` is true.",
+		schema.ListType(schema.NonNullType(schema.NamedType("__InputValue"))),
+	)
+	inputFieldsField.AddArgument(schema.NewInputValue(
+		"includeDeprecated",
+		"Include deprecated input fields in the results.",
+		schema.NamedType("Boolean"),
+	).SetDefault(false))
+	t.AddField(inputFieldsField)
+	t.AddField(schema.NewField(
+		"ofType",
+		"Wrapped type if this is a list or non-null.",
+		schema.NamedType("__Type"),
+	))
+	t.AddField(schema.NewField(
+		"specifiedByURL",
+		"URL that specifies the behaviour of this scalar.",
+		schema.NamedType("String"),
+	))
+	t.AddField(schema.NewField(
+		"isOneOf",
+		"Whether this input object represents a @oneOf specification.",
+		schema.NamedType("Boolean"),
+	))
+	return t
 }
 
 // fieldType returns the __Field introspection type definition
 func fieldType() *schema.Type {
-	return &schema.Type{
-		Name: "__Field",
-		Kind: schema.TypeKindObject,
-		Fields: []*schema.Field{
-			{Name: "name", Type: schema.NonNullType(schema.NamedType("String"))},
-			{Name: "description", Type: schema.NamedType("String")},
-			{
-				Name: "args",
-				Arguments: []*schema.InputValue{
-					{Name: "includeDeprecated", Type: schema.NamedType("Boolean"), DefaultValue: false},
-				},
-				Type: schema.NonNullType(schema.ListType(schema.NonNullType(schema.NamedType("__InputValue")))),
-			},
-			{Name: "type", Type: schema.NonNullType(schema.NamedType("__Type"))},
-			{Name: "isDeprecated", Type: schema.NonNullType(schema.NamedType("Boolean"))},
-			{Name: "deprecationReason", Type: schema.NamedType("String")},
-		},
-	}
+	t := schema.NewType(
+		"__Field",
+		schema.TypeKindObject,
+		"Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
+	)
+	t.AddField(schema.NewField(
+		"name",
+		"The name of the field.",
+		schema.NonNullType(schema.NamedType("String")),
+	))
+	t.AddField(schema.NewField(
+		"description",
+		"The description of the field.",
+		schema.NamedType("String"),
+	))
+	argsField := schema.NewField(
+		"args",
+		"Arguments accepted by this field.",
+		schema.NonNullType(schema.ListType(schema.NonNullType(schema.NamedType("__InputValue")))),
+	)
+	argsField.AddArgument(schema.NewInputValue(
+		"includeDeprecated",
+		"Include deprecated arguments in the results.",
+		schema.NamedType("Boolean"),
+	).SetDefault(false))
+	t.AddField(argsField)
+	t.AddField(schema.NewField(
+		"type",
+		"The return type of the field.",
+		schema.NonNullType(schema.NamedType("__Type")),
+	))
+	t.AddField(schema.NewField(
+		"isDeprecated",
+		"Whether this field is deprecated.",
+		schema.NonNullType(schema.NamedType("Boolean")),
+	))
+	t.AddField(schema.NewField(
+		"deprecationReason",
+		"Reason the field is deprecated, if any.",
+		schema.NamedType("String"),
+	))
+	return t
 }
 
 // inputValueType returns the __InputValue introspection type definition
 func inputValueType() *schema.Type {
-	return &schema.Type{
-		Name: "__InputValue",
-		Kind: schema.TypeKindObject,
-		Fields: []*schema.Field{
-			{Name: "name", Type: schema.NonNullType(schema.NamedType("String"))},
-			{Name: "description", Type: schema.NamedType("String")},
-			{Name: "type", Type: schema.NonNullType(schema.NamedType("__Type"))},
-			{Name: "defaultValue", Type: schema.NamedType("String")},
-			{Name: "isDeprecated", Type: schema.NonNullType(schema.NamedType("Boolean"))},
-			{Name: "deprecationReason", Type: schema.NamedType("String")},
-		},
-	}
+	t := schema.NewType(
+		"__InputValue",
+		schema.TypeKindObject,
+		"Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+	)
+	t.AddField(schema.NewField(
+		"name",
+		"The name of the input value.",
+		schema.NonNullType(schema.NamedType("String")),
+	))
+	t.AddField(schema.NewField(
+		"description",
+		"The description of the input value.",
+		schema.NamedType("String"),
+	))
+	t.AddField(schema.NewField(
+		"type",
+		"The expected type of the input value.",
+		schema.NonNullType(schema.NamedType("__Type")),
+	))
+	t.AddField(schema.NewField(
+		"defaultValue",
+		"A GraphQL-formatted string representing the default value for this input value.",
+		schema.NamedType("String"),
+	))
+	t.AddField(schema.NewField(
+		"isDeprecated",
+		"Whether this input value is deprecated.",
+		schema.NonNullType(schema.NamedType("Boolean")),
+	))
+	t.AddField(schema.NewField(
+		"deprecationReason",
+		"Reason the input value is deprecated, if any.",
+		schema.NamedType("String"),
+	))
+	return t
 }
 
 // enumValueType returns the __EnumValue introspection type definition
 func enumValueType() *schema.Type {
-	return &schema.Type{
-		Name: "__EnumValue",
-		Kind: schema.TypeKindObject,
-		Fields: []*schema.Field{
-			{Name: "name", Type: schema.NonNullType(schema.NamedType("String"))},
-			{Name: "description", Type: schema.NamedType("String")},
-			{Name: "isDeprecated", Type: schema.NonNullType(schema.NamedType("Boolean"))},
-			{Name: "deprecationReason", Type: schema.NamedType("String")},
-		},
-	}
+	t := schema.NewType(
+		"__EnumValue",
+		schema.TypeKindObject,
+		"One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+	)
+	t.AddField(schema.NewField(
+		"name",
+		"The name of the enum value.",
+		schema.NonNullType(schema.NamedType("String")),
+	))
+	t.AddField(schema.NewField(
+		"description",
+		"The description of the enum value.",
+		schema.NamedType("String"),
+	))
+	t.AddField(schema.NewField(
+		"isDeprecated",
+		"Whether this enum value is deprecated.",
+		schema.NonNullType(schema.NamedType("Boolean")),
+	))
+	t.AddField(schema.NewField(
+		"deprecationReason",
+		"Reason the enum value is deprecated, if any.",
+		schema.NamedType("String"),
+	))
+	return t
 }
 
 // directiveType returns the __Directive introspection type definition
 func directiveType() *schema.Type {
-	return &schema.Type{
-		Name: "__Directive",
-		Kind: schema.TypeKindObject,
-		Fields: []*schema.Field{
-			{Name: "name", Type: schema.NonNullType(schema.NamedType("String"))},
-			{Name: "description", Type: schema.NamedType("String")},
-			{Name: "isRepeatable", Type: schema.NonNullType(schema.NamedType("Boolean"))},
-			{Name: "locations", Type: schema.NonNullType(schema.ListType(schema.NonNullType(schema.NamedType("__DirectiveLocation"))))},
-			{
-				Name: "args",
-				Arguments: []*schema.InputValue{
-					{Name: "includeDeprecated", Type: schema.NamedType("Boolean"), DefaultValue: false},
-				},
-				Type: schema.NonNullType(schema.ListType(schema.NonNullType(schema.NamedType("__InputValue")))),
-			},
-		},
-	}
+	t := schema.NewType(
+		"__Directive",
+		schema.TypeKindObject,
+		"A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+	)
+	t.AddField(schema.NewField(
+		"name",
+		"The name of the directive.",
+		schema.NonNullType(schema.NamedType("String")),
+	))
+	t.AddField(schema.NewField(
+		"description",
+		"The description of the directive.",
+		schema.NamedType("String"),
+	))
+	t.AddField(schema.NewField(
+		"isRepeatable",
+		"Whether this directive may be used more than once at a single location.",
+		schema.NonNullType(schema.NamedType("Boolean")),
+	))
+	t.AddField(schema.NewField(
+		"locations",
+		"Locations this directive may be used in.",
+		schema.NonNullType(schema.ListType(schema.NonNullType(schema.NamedType("__DirectiveLocation")))),
+	))
+	argsField := schema.NewField(
+		"args",
+		"Arguments accepted by this directive.",
+		schema.NonNullType(schema.ListType(schema.NonNullType(schema.NamedType("__InputValue")))),
+	)
+	argsField.AddArgument(schema.NewInputValue(
+		"includeDeprecated",
+		"Include deprecated directive arguments in the results.",
+		schema.NamedType("Boolean"),
+	).SetDefault(false))
+	t.AddField(argsField)
+	return t
 }
 
 // typeKindEnum returns the __TypeKind enum type definition
 func typeKindEnum() *schema.Type {
-	return &schema.Type{
-		Name: "__TypeKind",
-		Kind: schema.TypeKindEnum,
-		EnumValues: []*schema.EnumValue{
-			{Name: "SCALAR"},
-			{Name: "OBJECT"},
-			{Name: "INTERFACE"},
-			{Name: "UNION"},
-			{Name: "ENUM"},
-			{Name: "INPUT_OBJECT"},
-			{Name: "LIST"},
-			{Name: "NON_NULL"},
-		},
-	}
+	t := schema.NewType(
+		"__TypeKind",
+		schema.TypeKindEnum,
+		"An enum describing what kind of type a given `__Type` is.",
+	)
+	t.AddEnumValue(schema.NewEnumValue("SCALAR", "Indicates this type is a scalar."))
+	t.AddEnumValue(schema.NewEnumValue("OBJECT", "Indicates this type is an object. `fields` and `interfaces` are valid fields."))
+	t.AddEnumValue(schema.NewEnumValue("INTERFACE", "Indicates this type is an interface. `fields`, `interfaces`, and `possibleTypes` are valid fields."))
+	t.AddEnumValue(schema.NewEnumValue("UNION", "Indicates this type is a union. `possibleTypes` is a valid field."))
+	t.AddEnumValue(schema.NewEnumValue("ENUM", "Indicates this type is an enum. `enumValues` is a valid field."))
+	t.AddEnumValue(schema.NewEnumValue("INPUT_OBJECT", "Indicates this type is an input object. `inputFields` is a valid field."))
+	t.AddEnumValue(schema.NewEnumValue("LIST", "Indicates this type is a list. `ofType` is a valid field."))
+	t.AddEnumValue(schema.NewEnumValue("NON_NULL", "Indicates this type is a non-null. `ofType` is a valid field."))
+	return t
 }
 
 // directiveLocationEnum returns the __DirectiveLocation enum type definition
 func directiveLocationEnum() *schema.Type {
-	return &schema.Type{
-		Name: "__DirectiveLocation",
-		Kind: schema.TypeKindEnum,
-		EnumValues: []*schema.EnumValue{
-			{Name: "QUERY"},
-			{Name: "MUTATION"},
-			{Name: "SUBSCRIPTION"},
-			{Name: "FIELD"},
-			{Name: "FRAGMENT_DEFINITION"},
-			{Name: "FRAGMENT_SPREAD"},
-			{Name: "INLINE_FRAGMENT"},
-			{Name: "VARIABLE_DEFINITION"},
-			{Name: "SCHEMA"},
-			{Name: "SCALAR"},
-			{Name: "OBJECT"},
-			{Name: "FIELD_DEFINITION"},
-			{Name: "ARGUMENT_DEFINITION"},
-			{Name: "INTERFACE"},
-			{Name: "UNION"},
-			{Name: "ENUM"},
-			{Name: "ENUM_VALUE"},
-			{Name: "INPUT_OBJECT"},
-			{Name: "INPUT_FIELD_DEFINITION"},
-		},
+	t := schema.NewType(
+		"__DirectiveLocation",
+		schema.TypeKindEnum,
+		"A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacency.",
+	)
+	locations := []struct {
+		Name, Description string
+	}{
+		{"QUERY", "Location adjacent to a query operation."},
+		{"MUTATION", "Location adjacent to a mutation operation."},
+		{"SUBSCRIPTION", "Location adjacent to a subscription operation."},
+		{"FIELD", "Location adjacent to a field."},
+		{"FRAGMENT_DEFINITION", "Location adjacent to a fragment definition."},
+		{"FRAGMENT_SPREAD", "Location adjacent to a fragment spread."},
+		{"INLINE_FRAGMENT", "Location adjacent to an inline fragment."},
+		{"VARIABLE_DEFINITION", "Location adjacent to a variable definition."},
+		{"SCHEMA", "Location adjacent to a schema definition."},
+		{"SCALAR", "Location adjacent to a scalar definition."},
+		{"OBJECT", "Location adjacent to an object type definition."},
+		{"FIELD_DEFINITION", "Location adjacent to a field definition."},
+		{"ARGUMENT_DEFINITION", "Location adjacent to an argument definition."},
+		{"INTERFACE", "Location adjacent to an interface definition."},
+		{"UNION", "Location adjacent to a union definition."},
+		{"ENUM", "Location adjacent to an enum definition."},
+		{"ENUM_VALUE", "Location adjacent to an enum value definition."},
+		{"INPUT_OBJECT", "Location adjacent to an input object type definition."},
+		{"INPUT_FIELD_DEFINITION", "Location adjacent to an input object field definition."},
 	}
+	for _, loc := range locations {
+		t.AddEnumValue(schema.NewEnumValue(loc.Name, loc.Description))
+	}
+	return t
+}
+
+func cloneField(src *schema.Field) *schema.Field {
+	if src == nil {
+		return nil
+	}
+	cloned := schema.NewField(src.Name, src.Description, src.Type).
+		SetAsync(src.Async)
+	if src.IsDeprecated {
+		cloned.Deprecate(src.DeprecationReason)
+	}
+	for _, arg := range src.GetOrderedArguments() {
+		cloned.AddArgument(cloneInputValue(arg))
+	}
+	cloned.Index = src.Index
+	return cloned
+}
+
+func cloneInputValue(src *schema.InputValue) *schema.InputValue {
+	cloned := schema.NewInputValue(src.Name, src.Description, src.Type).
+		SetDefault(src.DefaultValue)
+	if src.IsDeprecated {
+		cloned.Deprecate(src.DeprecationReason)
+	}
+	cloned.Index = src.Index
+	return cloned
 }

--- a/internal/schema/render.go
+++ b/internal/schema/render.go
@@ -120,7 +120,7 @@ func renderInputObject(b *strings.Builder, typ *Type) {
 		b.WriteString(" @oneOf")
 	}
 	b.WriteString(" {\n")
-	for _, field := range typ.InputFields {
+	for _, field := range typ.GetOrderedInputFields() {
 		renderDescription(b, field.Description)
 		b.WriteString("  ")
 		b.WriteString(field.Name)
@@ -157,7 +157,7 @@ func renderObject(b *strings.Builder, typ *Type) {
 		}
 	}
 	b.WriteString(" {\n")
-	for _, field := range typ.Fields {
+	for _, field := range typ.GetOrderedFields() {
 		renderField(b, field)
 	}
 	b.WriteString("}\n\n")
@@ -177,7 +177,7 @@ func renderInterface(b *strings.Builder, typ *Type) {
 		}
 	}
 	b.WriteString(" {\n")
-	for _, field := range typ.Fields {
+	for _, field := range typ.GetOrderedFields() {
 		renderField(b, field)
 	}
 	b.WriteString("}\n\n")
@@ -203,7 +203,7 @@ func renderField(b *strings.Builder, field *Field) {
 	b.WriteString(field.Name)
 	if len(field.Arguments) > 0 {
 		b.WriteString("(")
-		for i, arg := range field.Arguments {
+		for i, arg := range field.GetOrderedArguments() {
 			if i > 0 {
 				b.WriteString(", ")
 			}

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -1,5 +1,7 @@
 package schema
 
+import "sort"
+
 // Schema represents the complete GraphQL schema
 type Schema struct {
 	QueryType        string
@@ -8,6 +10,15 @@ type Schema struct {
 	Types            map[string]*Type // All named types keyed by name
 	Directives       map[string]*Directive
 	Description      string
+}
+
+// NewSchema constructs an empty schema with initialized maps.
+func NewSchema(description string) *Schema {
+	return &Schema{
+		Types:       make(map[string]*Type),
+		Directives:  make(map[string]*Directive),
+		Description: description,
+	}
 }
 
 // GetQueryType returns the root query type (may be nil if absent)
@@ -19,18 +30,123 @@ func (s *Schema) GetMutationType() *Type { return s.Types[s.MutationType] }
 // GetSubscriptionType returns the root subscription type (may be nil if absent)
 func (s *Schema) GetSubscriptionType() *Type { return s.Types[s.SubscriptionType] }
 
+// SetQueryType sets the schema's root query type name.
+func (s *Schema) SetQueryType(name string) *Schema {
+	s.QueryType = name
+	return s
+}
+
+// SetMutationType sets the schema's root mutation type name.
+func (s *Schema) SetMutationType(name string) *Schema {
+	s.MutationType = name
+	return s
+}
+
+// SetSubscriptionType sets the schema's root subscription type name.
+func (s *Schema) SetSubscriptionType(name string) *Schema {
+	s.SubscriptionType = name
+	return s
+}
+
+// AddType registers the given type on the schema, overriding by name.
+func (s *Schema) AddType(t *Type) *Schema {
+	s.Types[t.Name] = t
+	return s
+}
+
+// AddDirective registers the given directive on the schema, overriding by name.
+func (s *Schema) AddDirective(d *Directive) *Schema {
+	s.Directives[d.Name] = d
+	return s
+}
+
 // Type is a named GraphQL type (object, interface, union, scalar, enum, input)
 type Type struct {
 	Name           string
 	Kind           TypeKind
 	Description    string
-	Fields         []*Field      // For OBJECT and INTERFACE
-	Interfaces     []string      // For OBJECT and INTERFACE (implemented/extended)
-	PossibleTypes  []string      // For INTERFACE and UNION
-	EnumValues     []*EnumValue  // For ENUM
-	InputFields    []*InputValue // For INPUT_OBJECT
+	Fields         map[string]*Field      // For OBJECT and INTERFACE
+	Interfaces     []string               // For OBJECT and INTERFACE (implemented/extended)
+	PossibleTypes  []string               // For INTERFACE and UNION
+	EnumValues     []*EnumValue           // For ENUM
+	InputFields    map[string]*InputValue // For INPUT_OBJECT
 	SpecifiedByURL *string
 	OneOf          bool
+}
+
+// NewType constructs a type with initialized field and input-field maps.
+func NewType(name string, kind TypeKind, description string) *Type {
+	return &Type{
+		Name:        name,
+		Kind:        kind,
+		Description: description,
+		Fields:      make(map[string]*Field),
+		InputFields: make(map[string]*InputValue),
+	}
+}
+
+// SetDescription sets the type description.
+func (t *Type) SetDescription(description string) *Type {
+	t.Description = description
+	return t
+}
+
+// SetOneOf marks the type as a oneof input object.
+func (t *Type) SetOneOf(oneOf bool) *Type {
+	t.OneOf = oneOf
+	return t
+}
+
+// SetSpecifiedByURL sets or clears the specifiedBy URL for scalar types.
+func (t *Type) SetSpecifiedByURL(url string) *Type {
+	if url == "" {
+		t.SpecifiedByURL = nil
+		return t
+	}
+	t.SpecifiedByURL = &url
+	return t
+}
+
+// AddInterface records that the type implements the provided interface.
+func (t *Type) AddInterface(name string) *Type {
+	for _, existing := range t.Interfaces {
+		if existing == name {
+			return t
+		}
+	}
+	t.Interfaces = append(t.Interfaces, name)
+	return t
+}
+
+// AddPossibleType records a possible type for interfaces or unions.
+func (t *Type) AddPossibleType(name string) *Type {
+	for _, existing := range t.PossibleTypes {
+		if existing == name {
+			return t
+		}
+	}
+	t.PossibleTypes = append(t.PossibleTypes, name)
+	return t
+}
+
+// AddEnumValue appends an enum value definition.
+func (t *Type) AddEnumValue(value *EnumValue) *Type {
+	t.EnumValues = append(t.EnumValues, value)
+	return t
+}
+
+// AddField registers a field on the type, auto-assigning an index when absent.
+func (t *Type) AddField(field *Field) *Type {
+	field.Index = nextFieldIndex(t.Fields)
+	t.Fields[field.Name] = field
+	return t
+}
+
+// AddInputField registers an input field on the type, auto-assigning an index when absent.
+func (t *Type) AddInputField(input *InputValue) *Type {
+	input.Index = nextInputValueIndex(t.InputFields)
+	t.InputFields[input.Name] = input
+	return t
 }
 
 // Field represents a field on an object or interface
@@ -38,10 +154,41 @@ type Field struct {
 	Name              string
 	Description       string
 	Type              *TypeRef
-	Arguments         []*InputValue // formerly ArgumentDefinitionMap
+	Arguments         map[string]*InputValue
 	Async             bool
 	IsDeprecated      bool
 	DeprecationReason string
+	Index             int
+}
+
+// NewField constructs a field definition with the provided name, description, and type reference.
+func NewField(name, description string, typeRef *TypeRef) *Field {
+	return &Field{
+		Name:        name,
+		Description: description,
+		Type:        typeRef,
+		Arguments:   make(map[string]*InputValue),
+	}
+}
+
+// SetAsync marks whether the field resolves asynchronously.
+func (f *Field) SetAsync(async bool) *Field {
+	f.Async = async
+	return f
+}
+
+// Deprecate marks the field as deprecated with an optional reason.
+func (f *Field) Deprecate(reason string) *Field {
+	f.IsDeprecated = true
+	f.DeprecationReason = reason
+	return f
+}
+
+// AddArgument registers an argument definition for the field, assigning an index when absent.
+func (f *Field) AddArgument(arg *InputValue) *Field {
+	arg.Index = nextArgumentIndex(f.Arguments)
+	f.Arguments[arg.Name] = arg
+	return f
 }
 
 // TypeKind represents the kind of GraphQL type
@@ -111,6 +258,18 @@ type EnumValue struct {
 	DeprecationReason string
 }
 
+// NewEnumValue constructs an enum value definition.
+func NewEnumValue(name, description string) *EnumValue {
+	return &EnumValue{Name: name, Description: description}
+}
+
+// Deprecate marks the enum value as deprecated with an optional reason.
+func (e *EnumValue) Deprecate(reason string) *EnumValue {
+	e.IsDeprecated = true
+	e.DeprecationReason = reason
+	return e
+}
+
 type InputValue struct {
 	Name              string
 	Description       string
@@ -118,6 +277,31 @@ type InputValue struct {
 	DefaultValue      any
 	IsDeprecated      bool
 	DeprecationReason string
+	Index             int
+}
+
+// NewInputValue constructs an input value definition with the provided name, description, and type.
+func NewInputValue(name, description string, typeRef *TypeRef) *InputValue {
+	return &InputValue{Name: name, Description: description, Type: typeRef}
+}
+
+// SetDefault assigns the default value.
+func (v *InputValue) SetDefault(value any) *InputValue {
+	v.DefaultValue = value
+	return v
+}
+
+// SetIndex sets the input value order index.
+func (v *InputValue) SetIndex(index int) *InputValue {
+	v.Index = index
+	return v
+}
+
+// Deprecate marks the input value as deprecated with an optional reason.
+func (v *InputValue) Deprecate(reason string) *InputValue {
+	v.IsDeprecated = true
+	v.DeprecationReason = reason
+	return v
 }
 
 type Directive struct {
@@ -126,6 +310,35 @@ type Directive struct {
 	Locations    []string
 	Arguments    []*InputValue // formerly ArgumentDefinitionMap
 	IsRepeatable bool
+}
+
+// NewDirective constructs a directive definition with the provided name and description.
+func NewDirective(name, description string) *Directive {
+	return &Directive{Name: name, Description: description}
+}
+
+// SetRepeatable marks whether the directive is repeatable.
+func (d *Directive) SetRepeatable(repeatable bool) *Directive {
+	d.IsRepeatable = repeatable
+	return d
+}
+
+// AddLocation appends a directive location if not already present.
+func (d *Directive) AddLocation(location string) *Directive {
+	for _, existing := range d.Locations {
+		if existing == location {
+			return d
+		}
+	}
+	d.Locations = append(d.Locations, location)
+	return d
+}
+
+// AddArgument appends an argument definition, maintaining insertion order.
+func (d *Directive) AddArgument(arg *InputValue) *Directive {
+	arg.Index = len(d.Arguments)
+	d.Arguments = append(d.Arguments, arg)
+	return d
 }
 
 func NonNullType(t *TypeRef) *TypeRef { return &TypeRef{Kind: TypeRefKindNonNull, OfType: t} }
@@ -143,3 +356,119 @@ func Unwrap(t *TypeRef) *TypeRef { return t.Unwrap() }
 
 // GetNamedType returns the innermost named type for the given reference.
 func GetNamedType(t *TypeRef) string { return t.GetNamedType() }
+
+// Field returns the named field for object or interface types.
+func (t *Type) Field(name string) *Field {
+	return t.Fields[name]
+}
+
+// GetOrderedFields returns fields sorted by their index for deterministic iteration.
+func (t *Type) GetOrderedFields() []*Field {
+	if len(t.Fields) == 0 {
+		return nil
+	}
+	fields := make([]*Field, 0, len(t.Fields))
+	for _, f := range t.Fields {
+		fields = append(fields, f)
+	}
+	sort.Slice(fields, func(i, j int) bool { return fields[i].Index < fields[j].Index })
+	return fields
+}
+
+// InputField returns the named input field for input object types.
+func (t *Type) InputField(name string) *InputValue {
+	return t.InputFields[name]
+}
+
+// GetOrderedInputFields returns input fields sorted by their index for deterministic iteration.
+func (t *Type) GetOrderedInputFields() []*InputValue {
+	if len(t.InputFields) == 0 {
+		return nil
+	}
+	fields := make([]*InputValue, 0, len(t.InputFields))
+	for _, f := range t.InputFields {
+		fields = append(fields, f)
+	}
+	sort.Slice(fields, func(i, j int) bool { return fields[i].Index < fields[j].Index })
+	return fields
+}
+
+// Argument returns the named argument for the field, if present.
+func (f *Field) Argument(name string) *InputValue {
+	return f.Arguments[name]
+}
+
+// GetOrderedArguments returns field arguments sorted by their index for deterministic iteration.
+func (f *Field) GetOrderedArguments() []*InputValue {
+	if len(f.Arguments) == 0 {
+		return nil
+	}
+	args := make([]*InputValue, 0, len(f.Arguments))
+	for _, a := range f.Arguments {
+		args = append(args, a)
+	}
+	sort.Slice(args, func(i, j int) bool { return args[i].Index < args[j].Index })
+	return args
+}
+
+func nextFieldIndex(fields map[string]*Field) int {
+	max := -1
+	for _, f := range fields {
+		if f.Index > max {
+			max = f.Index
+		}
+	}
+	return max + 1
+}
+
+func nextInputValueIndex(values map[string]*InputValue) int {
+	max := -1
+	for _, v := range values {
+		if v.Index > max {
+			max = v.Index
+		}
+	}
+	return max + 1
+}
+
+func nextArgumentIndex(values map[string]*InputValue) int {
+	return nextInputValueIndex(values)
+}
+
+// NewFieldMap constructs a field map from the provided fields, assigning
+// sequential indexes when they are zero-valued.
+func NewFieldMap(fields ...*Field) map[string]*Field {
+	if len(fields) == 0 {
+		return nil
+	}
+	out := make(map[string]*Field, len(fields))
+	for i, field := range fields {
+		if field == nil || field.Name == "" {
+			continue
+		}
+		if field.Index == 0 && i > 0 {
+			field.Index = i
+		}
+		out[field.Name] = field
+	}
+	return out
+}
+
+// NewInputValueMap constructs an input value map from the provided values,
+// assigning sequential indexes when they are zero-valued.
+func NewInputValueMap(values ...*InputValue) map[string]*InputValue {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]*InputValue, len(values))
+	for i, value := range values {
+		if value == nil || value.Name == "" {
+			continue
+		}
+		if value.Index == 0 && i > 0 {
+			value.Index = i
+		}
+		out[value.Name] = value
+	}
+	return out
+}

--- a/internal/schema/testdata/schema_rendered.graphql
+++ b/internal/schema/testdata/schema_rendered.graphql
@@ -4,17 +4,17 @@ The Boolean scalar type represents true or false.
 scalar Boolean
 
 input CreateUserInput {
-  email: String!
   name: String!
+  email: String!
   role: UserRole = "USER"
 }
 
 scalar DateTime
 
 input ExtendedFilter {
-  keyword: String
-  priority: Priority
   status: ExtensionStatus
+  priority: Priority
+  keyword: String
 }
 
 enum ExtensionStatus {
@@ -42,7 +42,7 @@ scalar JSON
 
 type Mutation {
   createUser(input: CreateUserInput!): User!
-  updateUserBio(bio: String!, userId: ID!): Boolean
+  updateUserBio(userId: ID!, bio: String!): Boolean
 }
 
 interface Node {
@@ -57,11 +57,11 @@ enum Priority {
 }
 
 type Query {
-  getExtendedInfo: String
   getUser(id: ID!): User
-  listActiveUsers: [User!]!
   listUsers: [User!]!
   node(id: ID!): Node
+  getExtendedInfo: String
+  listActiveUsers: [User!]!
 }
 
 union SearchResult = User
@@ -73,24 +73,24 @@ scalar String
 
 interface Timestamped {
   createdAt: DateTime!
-  deletedAt: DateTime
   updatedAt: DateTime
+  deletedAt: DateTime
 }
 
 scalar URL
 
 type User implements Node & Timestamped {
-  bio: JSON
-  createdAt: DateTime!
-  deletedAt: DateTime
-  email: String!
   id: ID!
-  isExtended: Boolean
-  lastLoginAt: DateTime
   name: String!
+  email: String!
   role: UserRole!
   status: UserStatus!
+  createdAt: DateTime!
   updatedAt: DateTime
+  bio: JSON
+  lastLoginAt: DateTime
+  deletedAt: DateTime
+  isExtended: Boolean
 }
 
 enum UserRole {

--- a/internal/schema/testdata/schema_snapshot.json
+++ b/internal/schema/testdata/schema_snapshot.json
@@ -7,11 +7,11 @@
       "Name": "Boolean",
       "Kind": "SCALAR",
       "Description": "The Boolean scalar type represents true or false.",
-      "Fields": null,
+      "Fields": {},
       "Interfaces": null,
       "PossibleTypes": null,
       "EnumValues": null,
-      "InputFields": null,
+      "InputFields": {},
       "SpecifiedByURL": null,
       "OneOf": false
     },
@@ -19,12 +19,12 @@
       "Name": "CreateUserInput",
       "Kind": "INPUT_OBJECT",
       "Description": "",
-      "Fields": null,
+      "Fields": {},
       "Interfaces": null,
       "PossibleTypes": null,
       "EnumValues": null,
-      "InputFields": [
-        {
+      "InputFields": {
+        "email": {
           "Name": "email",
           "Description": "",
           "Type": {
@@ -38,9 +38,10 @@
           },
           "DefaultValue": null,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 1
         },
-        {
+        "name": {
           "Name": "name",
           "Description": "",
           "Type": {
@@ -54,9 +55,10 @@
           },
           "DefaultValue": null,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 0
         },
-        {
+        "role": {
           "Name": "role",
           "Description": "",
           "Type": {
@@ -66,9 +68,10 @@
           },
           "DefaultValue": "USER",
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 2
         }
-      ],
+      },
       "SpecifiedByURL": null,
       "OneOf": false
     },
@@ -76,11 +79,11 @@
       "Name": "DateTime",
       "Kind": "SCALAR",
       "Description": "",
-      "Fields": null,
+      "Fields": {},
       "Interfaces": null,
       "PossibleTypes": null,
       "EnumValues": null,
-      "InputFields": null,
+      "InputFields": {},
       "SpecifiedByURL": null,
       "OneOf": false
     },
@@ -88,12 +91,12 @@
       "Name": "ExtendedFilter",
       "Kind": "INPUT_OBJECT",
       "Description": "",
-      "Fields": null,
+      "Fields": {},
       "Interfaces": null,
       "PossibleTypes": null,
       "EnumValues": null,
-      "InputFields": [
-        {
+      "InputFields": {
+        "keyword": {
           "Name": "keyword",
           "Description": "",
           "Type": {
@@ -103,9 +106,10 @@
           },
           "DefaultValue": null,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 2
         },
-        {
+        "priority": {
           "Name": "priority",
           "Description": "",
           "Type": {
@@ -115,9 +119,10 @@
           },
           "DefaultValue": null,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 1
         },
-        {
+        "status": {
           "Name": "status",
           "Description": "",
           "Type": {
@@ -127,9 +132,10 @@
           },
           "DefaultValue": null,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 0
         }
-      ],
+      },
       "SpecifiedByURL": null,
       "OneOf": false
     },
@@ -137,7 +143,7 @@
       "Name": "ExtensionStatus",
       "Kind": "ENUM",
       "Description": "",
-      "Fields": null,
+      "Fields": {},
       "Interfaces": null,
       "PossibleTypes": null,
       "EnumValues": [
@@ -160,7 +166,7 @@
           "DeprecationReason": ""
         }
       ],
-      "InputFields": null,
+      "InputFields": {},
       "SpecifiedByURL": null,
       "OneOf": false
     },
@@ -168,11 +174,11 @@
       "Name": "Float",
       "Kind": "SCALAR",
       "Description": "The Float scalar type represents signed double-precision fractional values.",
-      "Fields": null,
+      "Fields": {},
       "Interfaces": null,
       "PossibleTypes": null,
       "EnumValues": null,
-      "InputFields": null,
+      "InputFields": {},
       "SpecifiedByURL": null,
       "OneOf": false
     },
@@ -180,11 +186,11 @@
       "Name": "ID",
       "Kind": "SCALAR",
       "Description": "The ID scalar type represents a unique identifier, often used to refetch an object or as a key for caching.",
-      "Fields": null,
+      "Fields": {},
       "Interfaces": null,
       "PossibleTypes": null,
       "EnumValues": null,
-      "InputFields": null,
+      "InputFields": {},
       "SpecifiedByURL": null,
       "OneOf": false
     },
@@ -192,11 +198,11 @@
       "Name": "Int",
       "Kind": "SCALAR",
       "Description": "The Int scalar type represents non-fractional signed whole numeric values.",
-      "Fields": null,
+      "Fields": {},
       "Interfaces": null,
       "PossibleTypes": null,
       "EnumValues": null,
-      "InputFields": null,
+      "InputFields": {},
       "SpecifiedByURL": null,
       "OneOf": false
     },
@@ -204,11 +210,11 @@
       "Name": "JSON",
       "Kind": "SCALAR",
       "Description": "",
-      "Fields": null,
+      "Fields": {},
       "Interfaces": null,
       "PossibleTypes": null,
       "EnumValues": null,
-      "InputFields": null,
+      "InputFields": {},
       "SpecifiedByURL": null,
       "OneOf": false
     },
@@ -216,8 +222,8 @@
       "Name": "Mutation",
       "Kind": "OBJECT",
       "Description": "",
-      "Fields": [
-        {
+      "Fields": {
+        "createUser": {
           "Name": "createUser",
           "Description": "",
           "Type": {
@@ -229,8 +235,8 @@
             },
             "Named": ""
           },
-          "Arguments": [
-            {
+          "Arguments": {
+            "input": {
               "Name": "input",
               "Description": "",
               "Type": {
@@ -244,14 +250,16 @@
               },
               "DefaultValue": null,
               "IsDeprecated": false,
-              "DeprecationReason": ""
+              "DeprecationReason": "",
+              "Index": 0
             }
-          ],
+          },
           "Async": true,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 0
         },
-        {
+        "updateUserBio": {
           "Name": "updateUserBio",
           "Description": "",
           "Type": {
@@ -259,8 +267,8 @@
             "OfType": null,
             "Named": "Boolean"
           },
-          "Arguments": [
-            {
+          "Arguments": {
+            "bio": {
               "Name": "bio",
               "Description": "",
               "Type": {
@@ -274,9 +282,10 @@
               },
               "DefaultValue": null,
               "IsDeprecated": false,
-              "DeprecationReason": ""
+              "DeprecationReason": "",
+              "Index": 1
             },
-            {
+            "userId": {
               "Name": "userId",
               "Description": "",
               "Type": {
@@ -290,18 +299,20 @@
               },
               "DefaultValue": null,
               "IsDeprecated": false,
-              "DeprecationReason": ""
+              "DeprecationReason": "",
+              "Index": 0
             }
-          ],
+          },
           "Async": true,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 1
         }
-      ],
+      },
       "Interfaces": null,
       "PossibleTypes": null,
       "EnumValues": null,
-      "InputFields": null,
+      "InputFields": {},
       "SpecifiedByURL": null,
       "OneOf": false
     },
@@ -309,8 +320,8 @@
       "Name": "Node",
       "Kind": "INTERFACE",
       "Description": "",
-      "Fields": [
-        {
+      "Fields": {
+        "id": {
           "Name": "id",
           "Description": "",
           "Type": {
@@ -322,16 +333,17 @@
             },
             "Named": ""
           },
-          "Arguments": null,
+          "Arguments": {},
           "Async": true,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 0
         }
-      ],
+      },
       "Interfaces": null,
       "PossibleTypes": null,
       "EnumValues": null,
-      "InputFields": null,
+      "InputFields": {},
       "SpecifiedByURL": null,
       "OneOf": false
     },
@@ -339,7 +351,7 @@
       "Name": "Priority",
       "Kind": "ENUM",
       "Description": "",
-      "Fields": null,
+      "Fields": {},
       "Interfaces": null,
       "PossibleTypes": null,
       "EnumValues": [
@@ -368,7 +380,7 @@
           "DeprecationReason": ""
         }
       ],
-      "InputFields": null,
+      "InputFields": {},
       "SpecifiedByURL": null,
       "OneOf": false
     },
@@ -376,8 +388,8 @@
       "Name": "Query",
       "Kind": "OBJECT",
       "Description": "",
-      "Fields": [
-        {
+      "Fields": {
+        "getExtendedInfo": {
           "Name": "getExtendedInfo",
           "Description": "",
           "Type": {
@@ -385,12 +397,13 @@
             "OfType": null,
             "Named": "String"
           },
-          "Arguments": null,
+          "Arguments": {},
           "Async": true,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 3
         },
-        {
+        "getUser": {
           "Name": "getUser",
           "Description": "",
           "Type": {
@@ -398,8 +411,8 @@
             "OfType": null,
             "Named": "User"
           },
-          "Arguments": [
-            {
+          "Arguments": {
+            "id": {
               "Name": "id",
               "Description": "",
               "Type": {
@@ -413,14 +426,16 @@
               },
               "DefaultValue": null,
               "IsDeprecated": false,
-              "DeprecationReason": ""
+              "DeprecationReason": "",
+              "Index": 0
             }
-          ],
+          },
           "Async": true,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 0
         },
-        {
+        "listActiveUsers": {
           "Name": "listActiveUsers",
           "Description": "",
           "Type": {
@@ -440,12 +455,13 @@
             },
             "Named": ""
           },
-          "Arguments": null,
+          "Arguments": {},
           "Async": true,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 4
         },
-        {
+        "listUsers": {
           "Name": "listUsers",
           "Description": "",
           "Type": {
@@ -465,12 +481,13 @@
             },
             "Named": ""
           },
-          "Arguments": null,
+          "Arguments": {},
           "Async": true,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 1
         },
-        {
+        "node": {
           "Name": "node",
           "Description": "",
           "Type": {
@@ -478,8 +495,8 @@
             "OfType": null,
             "Named": "Node"
           },
-          "Arguments": [
-            {
+          "Arguments": {
+            "id": {
               "Name": "id",
               "Description": "",
               "Type": {
@@ -493,18 +510,20 @@
               },
               "DefaultValue": null,
               "IsDeprecated": false,
-              "DeprecationReason": ""
+              "DeprecationReason": "",
+              "Index": 0
             }
-          ],
+          },
           "Async": true,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 2
         }
-      ],
+      },
       "Interfaces": null,
       "PossibleTypes": null,
       "EnumValues": null,
-      "InputFields": null,
+      "InputFields": {},
       "SpecifiedByURL": null,
       "OneOf": false
     },
@@ -512,13 +531,13 @@
       "Name": "SearchResult",
       "Kind": "UNION",
       "Description": "",
-      "Fields": null,
+      "Fields": {},
       "Interfaces": null,
       "PossibleTypes": [
         "User"
       ],
       "EnumValues": null,
-      "InputFields": null,
+      "InputFields": {},
       "SpecifiedByURL": null,
       "OneOf": false
     },
@@ -526,11 +545,11 @@
       "Name": "String",
       "Kind": "SCALAR",
       "Description": "The String scalar type represents textual data, represented as UTF-8 character sequences.",
-      "Fields": null,
+      "Fields": {},
       "Interfaces": null,
       "PossibleTypes": null,
       "EnumValues": null,
-      "InputFields": null,
+      "InputFields": {},
       "SpecifiedByURL": null,
       "OneOf": false
     },
@@ -538,8 +557,8 @@
       "Name": "Timestamped",
       "Kind": "INTERFACE",
       "Description": "",
-      "Fields": [
-        {
+      "Fields": {
+        "createdAt": {
           "Name": "createdAt",
           "Description": "",
           "Type": {
@@ -551,12 +570,13 @@
             },
             "Named": ""
           },
-          "Arguments": null,
+          "Arguments": {},
           "Async": true,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 0
         },
-        {
+        "deletedAt": {
           "Name": "deletedAt",
           "Description": "",
           "Type": {
@@ -564,12 +584,13 @@
             "OfType": null,
             "Named": "DateTime"
           },
-          "Arguments": null,
+          "Arguments": {},
           "Async": true,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 2
         },
-        {
+        "updatedAt": {
           "Name": "updatedAt",
           "Description": "",
           "Type": {
@@ -577,16 +598,17 @@
             "OfType": null,
             "Named": "DateTime"
           },
-          "Arguments": null,
+          "Arguments": {},
           "Async": true,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 1
         }
-      ],
+      },
       "Interfaces": null,
       "PossibleTypes": null,
       "EnumValues": null,
-      "InputFields": null,
+      "InputFields": {},
       "SpecifiedByURL": null,
       "OneOf": false
     },
@@ -594,11 +616,11 @@
       "Name": "URL",
       "Kind": "SCALAR",
       "Description": "",
-      "Fields": null,
+      "Fields": {},
       "Interfaces": null,
       "PossibleTypes": null,
       "EnumValues": null,
-      "InputFields": null,
+      "InputFields": {},
       "SpecifiedByURL": null,
       "OneOf": false
     },
@@ -606,8 +628,8 @@
       "Name": "User",
       "Kind": "OBJECT",
       "Description": "",
-      "Fields": [
-        {
+      "Fields": {
+        "bio": {
           "Name": "bio",
           "Description": "",
           "Type": {
@@ -615,12 +637,13 @@
             "OfType": null,
             "Named": "JSON"
           },
-          "Arguments": null,
+          "Arguments": {},
           "Async": true,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 7
         },
-        {
+        "createdAt": {
           "Name": "createdAt",
           "Description": "",
           "Type": {
@@ -632,12 +655,13 @@
             },
             "Named": ""
           },
-          "Arguments": null,
+          "Arguments": {},
           "Async": false,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 5
         },
-        {
+        "deletedAt": {
           "Name": "deletedAt",
           "Description": "",
           "Type": {
@@ -645,12 +669,13 @@
             "OfType": null,
             "Named": "DateTime"
           },
-          "Arguments": null,
+          "Arguments": {},
           "Async": true,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 9
         },
-        {
+        "email": {
           "Name": "email",
           "Description": "",
           "Type": {
@@ -662,12 +687,13 @@
             },
             "Named": ""
           },
-          "Arguments": null,
+          "Arguments": {},
           "Async": false,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 2
         },
-        {
+        "id": {
           "Name": "id",
           "Description": "",
           "Type": {
@@ -679,12 +705,13 @@
             },
             "Named": ""
           },
-          "Arguments": null,
+          "Arguments": {},
           "Async": false,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 0
         },
-        {
+        "isExtended": {
           "Name": "isExtended",
           "Description": "",
           "Type": {
@@ -692,12 +719,13 @@
             "OfType": null,
             "Named": "Boolean"
           },
-          "Arguments": null,
+          "Arguments": {},
           "Async": true,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 10
         },
-        {
+        "lastLoginAt": {
           "Name": "lastLoginAt",
           "Description": "",
           "Type": {
@@ -705,12 +733,13 @@
             "OfType": null,
             "Named": "DateTime"
           },
-          "Arguments": null,
+          "Arguments": {},
           "Async": true,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 8
         },
-        {
+        "name": {
           "Name": "name",
           "Description": "",
           "Type": {
@@ -722,12 +751,13 @@
             },
             "Named": ""
           },
-          "Arguments": null,
+          "Arguments": {},
           "Async": false,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 1
         },
-        {
+        "role": {
           "Name": "role",
           "Description": "",
           "Type": {
@@ -739,12 +769,13 @@
             },
             "Named": ""
           },
-          "Arguments": null,
+          "Arguments": {},
           "Async": false,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 3
         },
-        {
+        "status": {
           "Name": "status",
           "Description": "",
           "Type": {
@@ -756,12 +787,13 @@
             },
             "Named": ""
           },
-          "Arguments": null,
+          "Arguments": {},
           "Async": false,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 4
         },
-        {
+        "updatedAt": {
           "Name": "updatedAt",
           "Description": "",
           "Type": {
@@ -769,19 +801,20 @@
             "OfType": null,
             "Named": "DateTime"
           },
-          "Arguments": null,
+          "Arguments": {},
           "Async": false,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 6
         }
-      ],
+      },
       "Interfaces": [
         "Node",
         "Timestamped"
       ],
       "PossibleTypes": null,
       "EnumValues": null,
-      "InputFields": null,
+      "InputFields": {},
       "SpecifiedByURL": null,
       "OneOf": false
     },
@@ -789,7 +822,7 @@
       "Name": "UserRole",
       "Kind": "ENUM",
       "Description": "",
-      "Fields": null,
+      "Fields": {},
       "Interfaces": null,
       "PossibleTypes": null,
       "EnumValues": [
@@ -830,7 +863,7 @@
           "DeprecationReason": ""
         }
       ],
-      "InputFields": null,
+      "InputFields": {},
       "SpecifiedByURL": null,
       "OneOf": false
     },
@@ -838,7 +871,7 @@
       "Name": "UserStatus",
       "Kind": "ENUM",
       "Description": "",
-      "Fields": null,
+      "Fields": {},
       "Interfaces": null,
       "PossibleTypes": null,
       "EnumValues": [
@@ -861,7 +894,7 @@
           "DeprecationReason": ""
         }
       ],
-      "InputFields": null,
+      "InputFields": {},
       "SpecifiedByURL": null,
       "OneOf": false
     }
@@ -890,7 +923,8 @@
           },
           "DefaultValue": null,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 0
         }
       ],
       "IsRepeatable": false
@@ -918,7 +952,8 @@
           },
           "DefaultValue": null,
           "IsDeprecated": false,
-          "DeprecationReason": ""
+          "DeprecationReason": "",
+          "Index": 0
         }
       ],
       "IsRepeatable": false


### PR DESCRIPTION
- Changed Fields and InputFields in Type struct from slices to maps for better performance and easier access.
- Introduced methods to add fields and input fields, ensuring unique names and auto-assigning indices.
- Updated rendering functions to utilize new ordered field retrieval methods.
- Modified test data to reflect changes in field ordering and structure.
- Enhanced schema snapshot to align with new field representation.