### PR TITLE
Refactor executor tests to use schema constructors

### DIFF
--- a/internal/executor/executor_collect_test.go
+++ b/internal/executor/executor_collect_test.go
@@ -11,19 +11,10 @@ import (
 // Pattern: Result comparison
 func TestCollectFields_And_Directives_Result(t *testing.T) {
 	t.Run("Fragment merging and typename", func(t *testing.T) {
-		sch := &schema.Schema{
-			QueryType: "Query",
-			Types: map[string]*schema.Type{
-				"Query": {
-					Name: "Query",
-					Kind: schema.TypeKindObject,
-					Fields: map[string]*schema.Field{
-						"a": {Name: "a", Type: schema.NamedType("String"), Index: 0},
-					},
-				},
-				"String": {Name: "String", Kind: schema.TypeKindScalar},
-			},
-		}
+		sch := newSchemaWithQueryType(
+			newObjectType("Query", schema.NewField("a", "", schema.NamedType("String"))),
+			newScalarType("String"),
+		)
 		doc := mustParseQuery(t, `{
                         a
                         ...F1
@@ -48,21 +39,15 @@ func TestCollectFields_And_Directives_Result(t *testing.T) {
 	})
 
 	t.Run("Directives on scalar", func(t *testing.T) {
-		sch := &schema.Schema{
-			QueryType: "Query",
-			Types: map[string]*schema.Type{
-				"Query": {
-					Name: "Query",
-					Kind: schema.TypeKindObject,
-					Fields: map[string]*schema.Field{
-						"a": {Name: "a", Type: schema.NamedType("String"), Index: 0},
-						"b": {Name: "b", Type: schema.NamedType("String"), Index: 1},
-						"c": {Name: "c", Type: schema.NamedType("String"), Index: 2},
-					},
-				},
-				"String": {Name: "String", Kind: schema.TypeKindScalar},
-			},
-		}
+		sch := newSchemaWithQueryType(
+			newObjectType(
+				"Query",
+				schema.NewField("a", "", schema.NamedType("String")),
+				schema.NewField("b", "", schema.NamedType("String")),
+				schema.NewField("c", "", schema.NamedType("String")),
+			),
+			newScalarType("String"),
+		)
 		doc := mustParseQuery(t, `{ a b @skip(if: true) c @include(if: false) }`)
 		state := &executionState{schema: sch, document: doc, variableValues: map[string]any{}}
 		got := collectFields(state, sch.Types["Query"], doc.Operations[0].SelectionSet).orderedFields()
@@ -75,21 +60,15 @@ func TestCollectFields_And_Directives_Result(t *testing.T) {
 	})
 
 	t.Run("Directives on fragment spread", func(t *testing.T) {
-		sch := &schema.Schema{
-			QueryType: "Query",
-			Types: map[string]*schema.Type{
-				"Query": {
-					Name: "Query",
-					Kind: schema.TypeKindObject,
-					Fields: map[string]*schema.Field{
-						"a": {Name: "a", Type: schema.NamedType("String"), Index: 0},
-						"b": {Name: "b", Type: schema.NamedType("String"), Index: 1},
-						"c": {Name: "c", Type: schema.NamedType("String"), Index: 2},
-					},
-				},
-				"String": {Name: "String", Kind: schema.TypeKindScalar},
-			},
-		}
+		sch := newSchemaWithQueryType(
+			newObjectType(
+				"Query",
+				schema.NewField("a", "", schema.NamedType("String")),
+				schema.NewField("b", "", schema.NamedType("String")),
+				schema.NewField("c", "", schema.NamedType("String")),
+			),
+			newScalarType("String"),
+		)
 		doc := mustParseQuery(t, `{
                         a
                         ...Frag1 @include(if: true)
@@ -113,21 +92,15 @@ func TestCollectFields_And_Directives_Result(t *testing.T) {
 	})
 
 	t.Run("Directives on inline fragment", func(t *testing.T) {
-		sch := &schema.Schema{
-			QueryType: "Query",
-			Types: map[string]*schema.Type{
-				"Query": {
-					Name: "Query",
-					Kind: schema.TypeKindObject,
-					Fields: map[string]*schema.Field{
-						"a": {Name: "a", Type: schema.NamedType("String"), Index: 0},
-						"b": {Name: "b", Type: schema.NamedType("String"), Index: 1},
-						"c": {Name: "c", Type: schema.NamedType("String"), Index: 2},
-					},
-				},
-				"String": {Name: "String", Kind: schema.TypeKindScalar},
-			},
-		}
+		sch := newSchemaWithQueryType(
+			newObjectType(
+				"Query",
+				schema.NewField("a", "", schema.NamedType("String")),
+				schema.NewField("b", "", schema.NamedType("String")),
+				schema.NewField("c", "", schema.NamedType("String")),
+			),
+			newScalarType("String"),
+		)
 		doc := mustParseQuery(t, `{
                         a
                         ... on Query @include(if: true) { b }
@@ -148,21 +121,15 @@ func TestCollectFields_And_Directives_Result(t *testing.T) {
 	})
 
 	t.Run("Directives on anonymous inline fragment", func(t *testing.T) {
-		sch := &schema.Schema{
-			QueryType: "Query",
-			Types: map[string]*schema.Type{
-				"Query": {
-					Name: "Query",
-					Kind: schema.TypeKindObject,
-					Fields: schema.NewFieldMap(
-						&schema.Field{Name: "a", Type: schema.NamedType("String")},
-						&schema.Field{Name: "b", Type: schema.NamedType("String")},
-						&schema.Field{Name: "c", Type: schema.NamedType("String")},
-					),
-				},
-				"String": {Name: "String", Kind: schema.TypeKindScalar},
-			},
-		}
+		sch := newSchemaWithQueryType(
+			newObjectType(
+				"Query",
+				schema.NewField("a", "", schema.NamedType("String")),
+				schema.NewField("b", "", schema.NamedType("String")),
+				schema.NewField("c", "", schema.NamedType("String")),
+			),
+			newScalarType("String"),
+		)
 		doc := mustParseQuery(t, `{
                         a
                         ... @include(if: true) { b }

--- a/internal/executor/executor_errors_paths_test.go
+++ b/internal/executor/executor_errors_paths_test.go
@@ -12,13 +12,10 @@ import (
 // Pattern: Result comparison
 func TestErrors_LocatedPaths_Result(t *testing.T) {
 	t.Run("Simple", func(t *testing.T) {
-		sch := &schema.Schema{
-			QueryType: "Query",
-			Types: map[string]*schema.Type{
-				"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("String")})},
-				"String": {Name: "String", Kind: schema.TypeKindScalar},
-			},
-		}
+		sch := newSchemaWithQueryType(
+			newObjectType("Query", schema.NewField("a", "", schema.NamedType("String"))),
+			newScalarType("String"),
+		)
 		rt := NewMockRuntime(map[string]MockResolver{
 			"Query.a": NewMockErrorResolver(fmt.Errorf("boom")),
 		})
@@ -37,14 +34,11 @@ func TestErrors_LocatedPaths_Result(t *testing.T) {
 	})
 
 	t.Run("Nested", func(t *testing.T) {
-		sch := &schema.Schema{
-			QueryType: "Query",
-			Types: map[string]*schema.Type{
-				"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "obj", Type: schema.NamedType("Obj")})},
-				"Obj":    {Name: "Obj", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("String")})},
-				"String": {Name: "String", Kind: schema.TypeKindScalar},
-			},
-		}
+		sch := newSchemaWithQueryType(
+			newObjectType("Query", schema.NewField("obj", "", schema.NamedType("Obj"))),
+			newObjectType("Obj", schema.NewField("a", "", schema.NamedType("String"))),
+			newScalarType("String"),
+		)
 		rt := NewMockRuntime(map[string]MockResolver{
 			"Query.obj": NewMockValueResolver(map[string]any{}),
 			"Obj.a":     NewMockErrorResolver(fmt.Errorf("boom")),
@@ -64,14 +58,11 @@ func TestErrors_LocatedPaths_Result(t *testing.T) {
 	})
 
 	t.Run("List index in path", func(t *testing.T) {
-		sch := &schema.Schema{
-			QueryType: "Query",
-			Types: map[string]*schema.Type{
-				"Query":  {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "objs", Type: schema.ListType(schema.NamedType("Obj"))})},
-				"Obj":    {Name: "Obj", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("String")})},
-				"String": {Name: "String", Kind: schema.TypeKindScalar},
-			},
-		}
+		sch := newSchemaWithQueryType(
+			newObjectType("Query", schema.NewField("objs", "", schema.ListType(schema.NamedType("Obj")))),
+			newObjectType("Obj", schema.NewField("a", "", schema.NamedType("String"))),
+			newScalarType("String"),
+		)
 		rt := NewMockRuntime(map[string]MockResolver{
 			"Query.objs": NewMockValueResolver([]any{map[string]any{"idx": 0}, map[string]any{"idx": 1}}),
 			"Obj.a": func(ctx context.Context, src any, args map[string]any) (any, error) {

--- a/internal/executor/executor_ordering_test.go
+++ b/internal/executor/executor_ordering_test.go
@@ -10,21 +10,15 @@ import (
 
 // Pattern: Result comparison
 func TestOrdering_FieldOutput_Order_Result(t *testing.T) {
-	sch := &schema.Schema{
-		QueryType: "Query",
-		Types: map[string]*schema.Type{
-			"Query": {
-				Name: "Query",
-				Kind: schema.TypeKindObject,
-				Fields: schema.NewFieldMap(
-					&schema.Field{Name: "a", Type: schema.NamedType("String"), Async: false},
-					&schema.Field{Name: "b", Type: schema.NamedType("String"), Async: true},
-					&schema.Field{Name: "c", Type: schema.NamedType("String"), Async: false},
-				),
-			},
-			"String": {Name: "String", Kind: schema.TypeKindScalar},
-		},
-	}
+	sch := schema.NewSchema("").
+		SetQueryType("Query").
+		AddType(newObjectType(
+			"Query",
+			schema.NewField("a", "", schema.NamedType("String")),
+			schema.NewField("b", "", schema.NamedType("String")).SetAsync(true),
+			schema.NewField("c", "", schema.NamedType("String")),
+		)).
+		AddType(schema.NewType("String", schema.TypeKindScalar, ""))
 	rt := NewMockRuntime(map[string]MockResolver{
 		"Query.a": NewMockValueResolver("A"),
 		"Query.b": NewMockValueResolver("B"),
@@ -53,18 +47,16 @@ func TestOrdering_FieldOutput_Order_Result(t *testing.T) {
 
 // Pattern: Result comparison
 func TestOrdering_FragmentMerge_DuplicateFields_Result(t *testing.T) {
-	sch := &schema.Schema{
-		QueryType: "Query",
-		Types: map[string]*schema.Type{
-			"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "obj", Type: schema.NamedType("Obj")})},
-			"Obj":   {Name: "Obj", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("Sub")})},
-			"Sub": {Name: "Sub", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(
-				&schema.Field{Name: "x", Type: schema.NamedType("String")},
-				&schema.Field{Name: "y", Type: schema.NamedType("String")},
-			)},
-			"String": {Name: "String", Kind: schema.TypeKindScalar},
-		},
-	}
+	sch := schema.NewSchema("").
+		SetQueryType("Query").
+		AddType(newObjectType("Query", schema.NewField("obj", "", schema.NamedType("Obj")))).
+		AddType(newObjectType("Obj", schema.NewField("a", "", schema.NamedType("Sub")))).
+		AddType(newObjectType(
+			"Sub",
+			schema.NewField("x", "", schema.NamedType("String")),
+			schema.NewField("y", "", schema.NamedType("String")),
+		)).
+		AddType(schema.NewType("String", schema.TypeKindScalar, ""))
 	rt := NewMockRuntime(map[string]MockResolver{
 		"Query.obj": NewMockValueResolver(map[string]any{}),
 		"Obj.a":     NewMockValueResolver(map[string]any{}),

--- a/internal/executor/executor_runtime_contract_test.go
+++ b/internal/executor/executor_runtime_contract_test.go
@@ -11,16 +11,14 @@ import (
 
 // Pattern: Calls comparison
 func TestRuntimeContract_Routing_SyncVsBatch_Calls(t *testing.T) {
-	sch := &schema.Schema{
-		QueryType: "Query",
-		Types: map[string]*schema.Type{
-			"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(
-				&schema.Field{Name: "a", Type: schema.NamedType("String")},
-				&schema.Field{Name: "b", Type: schema.NamedType("String"), Async: true},
-			)},
-			"String": {Name: "String", Kind: schema.TypeKindScalar},
-		},
-	}
+	sch := newSchemaWithQueryType(
+		newObjectType(
+			"Query",
+			schema.NewField("a", "", schema.NamedType("String")),
+			schema.NewField("b", "", schema.NamedType("String")).SetAsync(true),
+		),
+		newScalarType("String"),
+	)
 	rt := NewMockRuntime(map[string]MockResolver{
 		"Query.a": NewMockValueResolver("A"),
 		"Query.b": NewMockValueResolver("B"),
@@ -42,18 +40,15 @@ func TestRuntimeContract_Routing_SyncVsBatch_Calls(t *testing.T) {
 
 // Pattern: Calls comparison
 func TestRuntimeContract_PayloadTransparency_Calls(t *testing.T) {
-	sch := &schema.Schema{
-		QueryType: "Query",
-		Types: map[string]*schema.Type{
-			"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "obj", Type: schema.NamedType("Obj")})},
-			"Obj": {
-				Name:   "Obj",
-				Kind:   schema.TypeKindObject,
-				Fields: schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("String"), Arguments: schema.NewInputValueMap(&schema.InputValue{Name: "arg", Type: schema.NamedType("String")})}),
-			},
-			"String": {Name: "String", Kind: schema.TypeKindScalar},
-		},
-	}
+	sch := newSchemaWithQueryType(
+		newObjectType("Query", schema.NewField("obj", "", schema.NamedType("Obj"))),
+		newObjectType(
+			"Obj",
+			schema.NewField("a", "", schema.NamedType("String")).
+				AddArgument(schema.NewInputValue("arg", "", schema.NamedType("String"))),
+		),
+		newScalarType("String"),
+	)
 	rt := NewMockRuntime(map[string]MockResolver{
 		"Query.obj": NewMockValueResolver(map[string]any{"token": "root"}),
 		"Obj.a":     func(ctx context.Context, src any, args map[string]any) (any, error) { return "A", nil },
@@ -75,16 +70,14 @@ func TestRuntimeContract_PayloadTransparency_Calls(t *testing.T) {
 
 // Pattern: Calls comparison
 func TestRuntimeContract_BatchBoundary_SingleBatchPerDepth_Calls(t *testing.T) {
-	sch := &schema.Schema{
-		QueryType: "Query",
-		Types: map[string]*schema.Type{
-			"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(
-				&schema.Field{Name: "a", Type: schema.NamedType("String"), Async: true},
-				&schema.Field{Name: "b", Type: schema.NamedType("String"), Async: true},
-			)},
-			"String": {Name: "String", Kind: schema.TypeKindScalar},
-		},
-	}
+	sch := newSchemaWithQueryType(
+		newObjectType(
+			"Query",
+			schema.NewField("a", "", schema.NamedType("String")).SetAsync(true),
+			schema.NewField("b", "", schema.NamedType("String")).SetAsync(true),
+		),
+		newScalarType("String"),
+	)
 	rt := NewMockRuntime(map[string]MockResolver{
 		"Query.a": NewMockValueResolver("A"),
 		"Query.b": NewMockValueResolver("B"),
@@ -106,20 +99,16 @@ func TestRuntimeContract_BatchBoundary_SingleBatchPerDepth_Calls(t *testing.T) {
 
 // Pattern: Calls + Result comparison
 func TestRuntimeContract_HookInvocation_Serialize_ResolveType_CallsAndResult(t *testing.T) {
-	sch := &schema.Schema{
-		QueryType: "Query",
-		Types: map[string]*schema.Type{
-			"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(&schema.Field{Name: "iface", Type: schema.NamedType("Node")})},
-			"Node":  {Name: "Node", Kind: schema.TypeKindInterface, PossibleTypes: []string{"Obj"}},
-			"Obj": {
-				Name:       "Obj",
-				Kind:       schema.TypeKindObject,
-				Interfaces: []string{"Node"},
-				Fields:     schema.NewFieldMap(&schema.Field{Name: "a", Type: schema.NamedType("String")}),
-			},
-			"String": {Name: "String", Kind: schema.TypeKindScalar},
-		},
-	}
+	nodeType := schema.NewType("Node", schema.TypeKindInterface, "").AddPossibleType("Obj")
+	objType := newObjectType("Obj", schema.NewField("a", "", schema.NamedType("String")))
+	objType.AddInterface("Node")
+
+	sch := newSchemaWithQueryType(
+		newObjectType("Query", schema.NewField("iface", "", schema.NamedType("Node"))),
+		nodeType,
+		objType,
+		newScalarType("String"),
+	)
 	rt := NewMockRuntime(map[string]MockResolver{
 		"Query.iface": NewMockValueResolver(map[string]any{}),
 		"Obj.a":       NewMockValueResolver("A"),
@@ -154,16 +143,14 @@ func TestRuntimeContract_HookInvocation_Serialize_ResolveType_CallsAndResult(t *
 
 // Pattern: Calls + Result comparison
 func TestRuntimeContract_CancellationTimeouts_PartialFailure_CallsAndResult(t *testing.T) {
-	sch := &schema.Schema{
-		QueryType: "Query",
-		Types: map[string]*schema.Type{
-			"Query": {Name: "Query", Kind: schema.TypeKindObject, Fields: schema.NewFieldMap(
-				&schema.Field{Name: "a", Type: schema.NamedType("String"), Async: true},
-				&schema.Field{Name: "b", Type: schema.NamedType("String"), Async: true},
-			)},
-			"String": {Name: "String", Kind: schema.TypeKindScalar},
-		},
-	}
+	sch := newSchemaWithQueryType(
+		newObjectType(
+			"Query",
+			schema.NewField("a", "", schema.NamedType("String")).SetAsync(true),
+			schema.NewField("b", "", schema.NamedType("String")).SetAsync(true),
+		),
+		newScalarType("String"),
+	)
 	rt := NewMockRuntime(map[string]MockResolver{
 		"Query.a": NewMockErrorResolver(fmt.Errorf("boom")),
 		"Query.b": NewMockValueResolver("B"),

--- a/internal/executor/schema_external_test_helpers_test.go
+++ b/internal/executor/schema_external_test_helpers_test.go
@@ -1,0 +1,27 @@
+package executor_test
+
+import schema "github.com/hanpama/protograph/internal/schema"
+
+func newSchemaWithQueryType(query *schema.Type, additional ...*schema.Type) *schema.Schema {
+	sch := schema.NewSchema("")
+	if query != nil {
+		sch.SetQueryType(query.Name)
+		sch.AddType(query)
+	}
+	for _, t := range additional {
+		sch.AddType(t)
+	}
+	return sch
+}
+
+func newObjectType(name string, fields ...*schema.Field) *schema.Type {
+	t := schema.NewType(name, schema.TypeKindObject, "")
+	for _, field := range fields {
+		t.AddField(field)
+	}
+	return t
+}
+
+func newScalarType(name string) *schema.Type {
+	return schema.NewType(name, schema.TypeKindScalar, "")
+}

--- a/internal/executor/schema_test_helpers.go
+++ b/internal/executor/schema_test_helpers.go
@@ -1,0 +1,27 @@
+package executor
+
+import schema "github.com/hanpama/protograph/internal/schema"
+
+func newSchemaWithQueryType(query *schema.Type, additional ...*schema.Type) *schema.Schema {
+	sch := schema.NewSchema("")
+	if query != nil {
+		sch.SetQueryType(query.Name)
+		sch.AddType(query)
+	}
+	for _, t := range additional {
+		sch.AddType(t)
+	}
+	return sch
+}
+
+func newObjectType(name string, fields ...*schema.Field) *schema.Type {
+	t := schema.NewType(name, schema.TypeKindObject, "")
+	for _, field := range fields {
+		t.AddField(field)
+	}
+	return t
+}
+
+func newScalarType(name string) *schema.Type {
+	return schema.NewType(name, schema.TypeKindScalar, "")
+}


### PR DESCRIPTION
## Summary
- add shared helpers for building schema instances in executor tests
- update executor package tests to use schema constructors and setters instead of struct literals
- update external executor tests to consume the new helpers while relying on constructor APIs

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ca855a9348832e8df478f0cdb1a7e0